### PR TITLE
Add cross-document view transitions

### DIFF
--- a/designs.html
+++ b/designs.html
@@ -29,6 +29,7 @@
 
   <link rel="modulepreload" href="/js/components/index.js" />
   <script type="module" src="/js/components/index.js"></script>
+  <script type="module" src="/js/view-transition.js"></script>
   <link href="/css/vars.css" rel="stylesheet" />
   <link href="/css/index.css" rel="stylesheet" />
 

--- a/experiments.html
+++ b/experiments.html
@@ -29,6 +29,7 @@
 
   <link rel="modulepreload" href="/js/components/index.js" />
   <script type="module" src="/js/components/index.js"></script>
+  <script type="module" src="/js/view-transition.js"></script>
   <link href="/css/vars.css" rel="stylesheet" />
   <link href="/css/index.css" rel="stylesheet" />
 

--- a/fundamentals/index.html
+++ b/fundamentals/index.html
@@ -31,6 +31,7 @@
 
   <link rel="modulepreload" href="/js/components/index.js" />
   <script type="module" src="/js/components/index.js"></script>
+  <script type="module" src="/js/view-transition.js"></script>
   <link href="/css/vars.css" rel="stylesheet" />
   <link href="/css/index.css" rel="stylesheet" />
 

--- a/fundamentals/simplicity.html
+++ b/fundamentals/simplicity.html
@@ -31,6 +31,7 @@
 
   <link rel="modulepreload" href="../js/components/index.js" />
   <script type="module" src="../js/components/index.js"></script>
+  <script type="module" src="../js/view-transition.js"></script>
   <link href="../css/vars.css" rel="stylesheet" />
   <link href="../css/index.css" rel="stylesheet" />
 

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
   <script src="/js/index.js"></script>
   <link rel="modulepreload" href="/js/components/index.js" />
   <script type="module" src="/js/components/index.js"></script>
+  <script type="module" src="/js/view-transition.js"></script>
   <link href="../css/vars.css" rel="stylesheet" />
   <link href="../css/index.css" rel="stylesheet" />
 

--- a/js/view-transition.js
+++ b/js/view-transition.js
@@ -1,0 +1,16 @@
+if ('startViewTransition' in document) {
+  document.addEventListener('click', (event) => {
+    const link = event.target.closest('a');
+    if (!link) return;
+    // Only handle same-origin navigations without target="_blank" or download
+    const url = new URL(link.href, location.href);
+    if (url.origin !== location.origin) return;
+    if (link.target && link.target !== '_self') return;
+    if (link.hasAttribute('download')) return;
+    if (url.pathname === location.pathname && !url.hash) return;
+    event.preventDefault();
+    document.startViewTransition(() => {
+      location.href = link.href;
+    });
+  });
+}

--- a/resources.html
+++ b/resources.html
@@ -36,6 +36,7 @@
 
   <link rel="modulepreload" href="/js/components/index.js" />
   <script type="module" src="/js/components/index.js"></script>
+  <script type="module" src="/js/view-transition.js"></script>
 
 
   <!-- Prefetch Links -->

--- a/test.html
+++ b/test.html
@@ -36,6 +36,7 @@
 
     <link rel="modulepreload" href="/js/components/index.js" />
     <script type="module" src="/js/components/index.js"></script>
+    <script type="module" src="/js/view-transition.js"></script>
 
 
     <!-- Prefetch Links -->


### PR DESCRIPTION
## Summary
- integrate a new view transition script to smooth page navigation
- load the view transition script on all pages

## Testing
- `npm test` *(fails: could not read package.json)*