### PR TITLE
Fix internal links

### DIFF
--- a/designs.html
+++ b/designs.html
@@ -35,7 +35,7 @@
 
   <!-- Prefetch Links -->
   <link rel="expect" href="/index.html" blocking="render" />
-  <link rel="expect" href="/fundamentals.html" blocking="render" />
+  <link rel="expect" href="/fundamentals/" blocking="render" />
   <link rel="expect" href="/experiments.html" blocking="render" />
   <link rel="expect" href="/resources.html" blocking="render" />
 
@@ -46,7 +46,7 @@
             "urls": [
               "index.html",
               "designs.html",
-              "fundamentals.html",
+              "fundamentals/",
               "experiments.html",
               "resources.html"
             ],

--- a/experiments.html
+++ b/experiments.html
@@ -34,10 +34,10 @@
   <link href="/assets/css/index.css" rel="stylesheet" />
 
   <!-- Prefetch Links -->
-  <link rel="expect" href="index.html" blocking="render" />
-  <link rel="expect" href="fundamentals.html" blocking="render" />
-  <link rel="expect" href="designs.html" blocking="render" />
-  <link rel="expect" href="resources.html" blocking="render" />
+  <link rel="expect" href="/index.html" blocking="render" />
+  <link rel="expect" href="/fundamentals/" blocking="render" />
+  <link rel="expect" href="/designs.html" blocking="render" />
+  <link rel="expect" href="/resources.html" blocking="render" />
   
   <script type="speculationrules">
       {
@@ -46,7 +46,7 @@
             "urls": [
               "index.html",
               "designs.html",
-              "fundamentals.html",
+              "fundamentals/",
               "experiments.html",
               "resources.html"
             ],
@@ -79,25 +79,25 @@
           </a>
         </li>
         <li>
-          <a class="nav-item item2" href="fundamentals.html">
+          <a class="nav-item item2" href="/fundamentals/">
             <span class="icon" role="img" aria-hidden="true">psychology</span>
             <span class="title">Fundamentals</span>
           </a>
         </li>
         <li>
-          <a class="nav-item item3" href="designs.html">
+          <a class="nav-item item3" href="/designs.html">
             <span class="icon" role="img" aria-hidden="true">web</span>
             <span class="title">Designs</span>
           </a>
         </li>
         <li>
-          <a class="nav-item item4 active" href="experiments.html">
+          <a class="nav-item item4 active" href="/experiments.html">
             <span class="icon" role="img" aria-hidden="true">experiment</span>
             <span class="title">Experiments</span>
           </a>
         </li>
         <li>
-          <a class="nav-item item5" href="resources.html">
+          <a class="nav-item item5" href="/resources.html">
             <span class="icon" role="img" aria-hidden="true">folder_open</span>
             <span class="title">Resources</span>
           </a>

--- a/fundamentals/index.html
+++ b/fundamentals/index.html
@@ -44,7 +44,7 @@
     {
       "prerender": [
         {
-          "urls": ["index.html", "designs.html","fundamentals.html","experiments.html","resources.html"],
+          "urls": ["index.html", "designs.html","fundamentals/","experiments.html","resources.html"],
           "eagerness": "eager",
           "referrer_policy": "same-origin"
         }

--- a/fundamentals/simplicity.html
+++ b/fundamentals/simplicity.html
@@ -36,15 +36,15 @@
   <link href="/assets/css/index.css" rel="stylesheet" />
 
   <!-- Prefetch Links -->
-  <link rel="expect" href="index.html" blocking="render" />
-  <link rel="expect" href="designs.html" blocking="render" />
-  <link rel="expect" href="experiments.html" blocking="render" />
-  <link rel="expect" href="resources.html" blocking="render" />
+  <link rel="expect" href="/index.html" blocking="render" />
+  <link rel="expect" href="/designs.html" blocking="render" />
+  <link rel="expect" href="/experiments.html" blocking="render" />
+  <link rel="expect" href="/resources.html" blocking="render" />
   <script type="speculationrules">
     {
       "prerender": [
         {
-          "urls": ["index.html", "designs.html","fundamentals.html","experiments.html","resources.html"],
+          "urls": ["index.html", "designs.html","fundamentals/","experiments.html","resources.html"],
           "eagerness": "eager",
           "referrer_policy": "same-origin"
         }
@@ -70,7 +70,7 @@
             <span class="icon" role="presentation" aria-hidden="true">waving_hand</span>
             <span class="title">Home</span>
           </a></li>
-        <li><a class="nav-item item2 active" href="/fundamentals">
+        <li><a class="nav-item item2 active" href="/fundamentals/">
             <span class="icon" role="presentation" aria-hidden="true">psychology</span>
             <span class="title">Fundamentals</span>
           </a></li>
@@ -78,11 +78,11 @@
             <span class="icon" role="presentation" aria-hidden="true">web</span>
             <span class="title">Designs</span>
           </a></li>
-        <li><a class="nav-item item4 " href="experiments.html">
+        <li><a class="nav-item item4 " href="/experiments.html">
             <span class="icon" role="presentation" aria-hidden="true">experiment</span>
             <span class="title">Experiments</span>
           </a></li>
-        <li><a class="nav-item item5" href="resources.html">
+        <li><a class="nav-item item5" href="/resources.html">
             <span class="icon" role="presentation" aria-hidden="true">folder_open</span>
             <span class="title">Resources</span>
           </a></li>

--- a/index.html
+++ b/index.html
@@ -33,14 +33,14 @@
 
   <!-- Prefetch Links -->
   <link rel="expect" href="/designs.html" blocking="render" />
-  <link rel="expect" href="/fundamentals.html" blocking="render" />
+  <link rel="expect" href="/fundamentals/" blocking="render" />
   <link rel="expect" href="/experiments.html" blocking="render" />
   <link rel="expect" href="/resources.html" blocking="render" />
   <script type="speculationrules">
     {
       "prerender": [
         {
-          "urls": ["index.html", "designs.html","fundamentals.html","experiments.html","resources.html"],
+          "urls": ["index.html", "designs.html","fundamentals/","experiments.html","resources.html"],
           "eagerness": "eager",
           "referrer_policy": "same-origin"
         }
@@ -68,7 +68,7 @@
             <span class="icon" role="img" aria-hidden="true">waving_hand</span>
             <span class="title">Home</span>
           </a></li>
-        <li><a class="nav-item item2" href="/fundamentals/index.html">
+        <li><a class="nav-item item2" href="/fundamentals/">
             <span class="icon" role="img" aria-hidden="true">psychology</span>
             <span class="title">Fundamentals</span>
           </a></li>

--- a/resources.html
+++ b/resources.html
@@ -40,15 +40,15 @@
 
 
   <!-- Prefetch Links -->
-  <link rel="expect" href="index.html" blocking="render" />
-  <link rel="expect" href="fundamentals.html" blocking="render" />
-  <link rel="expect" href="experiments.html" blocking="render" />
-  <link rel="expect" href="designs.html" blocking="render" />
+  <link rel="expect" href="/index.html" blocking="render" />
+  <link rel="expect" href="fundamentals/" blocking="render" />
+  <link rel="expect" href="/experiments.html" blocking="render" />
+  <link rel="expect" href="/designs.html" blocking="render" />
   <script type="speculationrules">
     {
       "prerender": [
         {
-          "urls": ["index.html", "designs.html","fundamentals.html","experiments.html","resources.html"],
+          "urls": ["index.html", "designs.html","fundamentals/","experiments.html","resources.html"],
           "eagerness": "eager",
           "referrer_policy": "same-origin"
         }
@@ -75,19 +75,19 @@
             <span class="icon" role="img" aria-hidden="true">waving_hand</span>
             <span class="title">Home</span>
           </a></li>
-        <li><a class="nav-item item2" href="fundamentals.html">
+        <li><a class="nav-item item2" href="/fundamentals/">
             <span class="icon" role="img" aria-hidden="true">psychology</span>
             <span class="title">Fundamentals</span>
           </a></li>
-        <li><a class="nav-item item3 " href="designs.html">
+        <li><a class="nav-item item3 " href="/designs.html">
             <span class="icon" role="img" aria-hidden="true">web</span>
             <span class="title">Designs</span>
           </a></li>
-        <li><a class="nav-item item4 " href="experiments.html">
+        <li><a class="nav-item item4 " href="/experiments.html">
             <span class="icon" role="img" aria-hidden="true">experiment</span>
             <span class="title">Experiments</span>
           </a></li>
-        <li><a class="nav-item item5 active" href="resources.html">
+        <li><a class="nav-item item5 active" href="/resources.html">
             <span class="icon" role="img" aria-hidden="true">folder_open</span>
             <span class="title">Resources</span>
           </a></li>

--- a/test.html
+++ b/test.html
@@ -40,15 +40,15 @@
 
 
     <!-- Prefetch Links -->
-    <link rel="expect" href="index.html" blocking="render" />
-    <link rel="expect" href="fundamentals.html" blocking="render" />
-    <link rel="expect" href="experiments.html" blocking="render" />
-    <link rel="expect" href="designs.html" blocking="render" />
+    <link rel="expect" href="/index.html" blocking="render" />
+    <link rel="expect" href="/fundamentals/" blocking="render" />
+    <link rel="expect" href="/experiments.html" blocking="render" />
+    <link rel="expect" href="/designs.html" blocking="render" />
     <script type="speculationrules">
     {
       "prerender": [
         {
-          "urls": ["index.html", "designs.html","fundamentals.html","experiments.html","resources.html"],
+          "urls": ["index.html", "designs.html","fundamentals/","experiments.html","resources.html"],
           "eagerness": "eager",
           "referrer_policy": "same-origin"
         }


### PR DESCRIPTION
## Summary
- correct links to the fundamentals page
- update speculation rule URL lists
- use absolute links in navigation menus and prefetch tags

## Testing
- `npm test` *(fails: Could not read package.json)*