### PR TITLE
Optimize font loading for icons

### DIFF
--- a/assets/css/global/typography.css
+++ b/assets/css/global/typography.css
@@ -100,9 +100,13 @@ u {
   }
 }
 
-.icon {
 
-width: fit-content;
+.icon {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  overflow: hidden;
+  text-align: center;
 
   font-family: var(--icon-font-family, "Material Symbols Sharp");
   font-size: var(--icon-size-large);

--- a/designs.html
+++ b/designs.html
@@ -15,12 +15,20 @@
   </script>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link
+  <link rel="preload"
     href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap"
-    rel="stylesheet" />
-  <link
+    as="style" onload="this.rel='stylesheet'" />
+  <link rel="preload"
     href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block"
-    rel="stylesheet" />
+    as="style" onload="this.rel='stylesheet'" />
+  <noscript>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap"
+      rel="stylesheet" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block"
+      rel="stylesheet" />
+  </noscript>
   
   <title>Ben Jennings</title>
   <meta charset="UTF-8" />

--- a/experiments.html
+++ b/experiments.html
@@ -15,12 +15,20 @@
   </script>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link
+  <link rel="preload"
     href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap"
-    rel="stylesheet" />
-  <link
+    as="style" onload="this.rel='stylesheet'" />
+  <link rel="preload"
     href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block"
-    rel="stylesheet" />
+    as="style" onload="this.rel='stylesheet'" />
+  <noscript>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap"
+      rel="stylesheet" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block"
+      rel="stylesheet" />
+  </noscript>
   
   <title>Ben Jennings</title>
   <meta charset="UTF-8" />

--- a/fundamentals/index.html
+++ b/fundamentals/index.html
@@ -15,12 +15,20 @@
   </script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link
+  <link rel="preload"
     href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap"
-    rel="stylesheet">
-  <link
+    as="style" onload="this.rel='stylesheet'">
+  <link rel="preload"
     href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block"
-    rel="stylesheet">
+    as="style" onload="this.rel='stylesheet'">
+  <noscript>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap"
+      rel="stylesheet">
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block"
+      rel="stylesheet">
+  </noscript>
   
   </style>
   <title>Ben Jennings</title>

--- a/fundamentals/simplicity.html
+++ b/fundamentals/simplicity.html
@@ -15,12 +15,20 @@
   </script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link
+  <link rel="preload"
     href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap"
-    rel="stylesheet">
-  <link
+    as="style" onload="this.rel='stylesheet'">
+  <link rel="preload"
     href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block"
-    rel="stylesheet">
+    as="style" onload="this.rel='stylesheet'">
+  <noscript>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap"
+      rel="stylesheet">
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block"
+      rel="stylesheet">
+  </noscript>
   
   </style>
   <title>Ben Jennings</title>

--- a/index.html
+++ b/index.html
@@ -15,12 +15,20 @@
   </script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link
+  <link rel="preload"
     href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap"
-    rel="stylesheet">
-  <link
+    as="style" onload="this.rel='stylesheet'">
+  <link rel="preload"
     href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block"
-    rel="stylesheet">
+    as="style" onload="this.rel='stylesheet'">
+  <noscript>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap"
+      rel="stylesheet">
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block"
+      rel="stylesheet">
+  </noscript>
 
   <title>Ben Jennings</title>
   <meta charset="UTF-8">

--- a/resources.html
+++ b/resources.html
@@ -17,12 +17,20 @@
   </script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link
+  <link rel="preload"
     href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap"
-    rel="stylesheet">
-  <link
+    as="style" onload="this.rel='stylesheet'">
+  <link rel="preload"
     href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&icon_names=account_balance,account_tree,close,cloud,construction,dark_mode,demography,deployed_code,design_services,developer_board,experiment,folder_open,integration_instructions,light_mode,link,psychology,psychology_alt,routine,tune,view_in_ar,waving_hand,web&display=block"
-    rel="stylesheet">
+    as="style" onload="this.rel='stylesheet'">
+  <noscript>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap"
+      rel="stylesheet">
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&icon_names=account_balance,account_tree,close,cloud,construction,dark_mode,demography,deployed_code,design_services,developer_board,experiment,folder_open,integration_instructions,light_mode,link,psychology,psychology_alt,routine,tune,view_in_ar,waving_hand,web&display=block"
+      rel="stylesheet">
+  </noscript>
   
   <link href="/assets/css/vars.css" rel="stylesheet" />
   <link href="/assets/css/index.css" rel="stylesheet" />

--- a/test.html
+++ b/test.html
@@ -17,12 +17,20 @@
     </script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link
+    <link rel="preload"
         href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap"
-        rel="stylesheet">
-    <link
+        as="style" onload="this.rel='stylesheet'">
+    <link rel="preload"
         href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&icon_names=account_balance,account_tree,close,cloud,construction,dark_mode,demography,deployed_code,design_services,developer_board,experiment,folder_open,integration_instructions,light_mode,link,psychology,psychology_alt,routine,tune,view_in_ar,waving_hand,web&display=block"
-        rel="stylesheet">
+        as="style" onload="this.rel='stylesheet'">
+    <noscript>
+        <link
+            href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap"
+            rel="stylesheet">
+        <link
+            href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&icon_names=account_balance,account_tree,close,cloud,construction,dark_mode,demography,deployed_code,design_services,developer_board,experiment,folder_open,integration_instructions,light_mode,link,psychology,psychology_alt,routine,tune,view_in_ar,waving_hand,web&display=block"
+            rel="stylesheet">
+    </noscript>
     
     <link href="/assets/css/vars.css" rel="stylesheet" />
     <link href="/assets/css/index.css" rel="stylesheet" />


### PR DESCRIPTION
## Summary
- avoid layout shift from icon text by fixing `.icon` width
- preload fonts across pages to speed up rendering

## Testing
- `git status --short`