### PR TITLE
Persist contrast setting

### DIFF
--- a/assets/js/components/color-changer.js
+++ b/assets/js/components/color-changer.js
@@ -47,6 +47,7 @@
               // Generate a random contrast value between 0.50 and 1.50
               const randomContrast = (Math.random() + 0.5).toFixed(2);
               document.documentElement.style.setProperty('--contrast', randomContrast);
+              localStorage.setItem('contrast', randomContrast);
               console.log(`--contrast set to: ${randomContrast}`);
 
                 console.log(`--brand-hue set to: ${randomHue}deg`);

--- a/assets/js/components/settings.js
+++ b/assets/js/components/settings.js
@@ -58,6 +58,10 @@ class SiteSettings extends HTMLElement {
     if (storedHueOffset) {
       document.documentElement.style.setProperty('--hue-offset-base', storedHueOffset + 'deg');
     }
+    const storedContrast = localStorage.getItem('contrast');
+    if (storedContrast) {
+      document.documentElement.style.setProperty('--contrast', storedContrast);
+    }
     // Apply persisted text heading width if available
     const storedTextHeadingWidth = localStorage.getItem('textHeadingWidth');
     if (storedTextHeadingWidth) {
@@ -111,6 +115,11 @@ class SiteSettings extends HTMLElement {
     const randomTextHeadingGrade = Math.floor(Math.random() * 101);
     document.documentElement.style.setProperty('--text-heading-grade', randomTextHeadingGrade);
     localStorage.setItem('textHeadingGrade', randomTextHeadingGrade);
+
+    // Random contrast 0.50–1.50
+    const randomContrast = (Math.random() + 0.5).toFixed(2);
+    document.documentElement.style.setProperty('--contrast', randomContrast);
+    localStorage.setItem('contrast', randomContrast);
 
     console.log(`--brand-hue set to: ${randomHue}deg`);
     // Persist random values so they survive page loads

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -8,6 +8,7 @@
     const selectedRadius = localStorage.getItem('baseRadius');
     const selectedChroma = localStorage.getItem('chromaBase');
     const selectedHueOffset = localStorage.getItem('hueOffsetBase');
+    const selectedContrast = localStorage.getItem('contrast');
 
     // Determine the color scheme based on theme setting
     const colorScheme = theme === 'system' ? 'light dark' : theme;
@@ -33,6 +34,11 @@
     // Apply persisted hue-offset-base if available
     if (selectedHueOffset) {
       document.documentElement.style.setProperty('--hue-offset-base', selectedHueOffset + 'deg');
+    }
+
+    // Apply persisted contrast if available
+    if (selectedContrast) {
+      document.documentElement.style.setProperty('--contrast', selectedContrast);
     }
   } catch (e) {
     console.error('Error applying theme preferences:', e);


### PR DESCRIPTION
## Summary
- store random contrast in localStorage when changing colors
- read the stored value on startup and during settings load

## Testing
- `npm test` *(fails: Error: no test specified)*