### PR TITLE
Add theme-control across site

### DIFF
--- a/assets/js/components/settings.js
+++ b/assets/js/components/settings.js
@@ -20,21 +20,7 @@ template.innerHTML = `
       
     </label>
   </fieldset>
-  <fieldset class="radio-buttons" id="data-theme-selector">
-    <label class="radio-button">
-      <input type="radio" name="dataTheme" value="calm" aria-label="Calm">
-      <span>Calm</span>
-    </label>
-    <label class="radio-button">
-      <input type="radio" name="dataTheme" value="balanced" aria-label="Balanced">
-      <span>Balanced</span>
-    </label>
-    <label class="radio-button">
-      <input type="radio" name="dataTheme" value="energized" aria-label="Energized">
-      <span>Energized</span>
-    </label>
-  </fieldset>
-  <button part="button" id="change-hue">Change Hue</button>
+
 `;
 
 class SiteSettings extends HTMLElement {
@@ -43,8 +29,6 @@ class SiteSettings extends HTMLElement {
     this.attachShadow({ mode: "open" });
     this.shadowRoot.appendChild(template.content.cloneNode(true));
     this.themeChangeHandler = this.themeChangeHandler.bind(this);
-    this.dataThemeChangeHandler = this.dataThemeChangeHandler.bind(this);
-    this.changeHue = this.changeHue.bind(this);
   }
 
   connectedCallback() {
@@ -53,9 +37,6 @@ class SiteSettings extends HTMLElement {
     if (selected) selected.checked = true;
     this.updateTheme(storedTheme);
     this.shadowRoot.querySelector("fieldset").addEventListener("change", this.themeChangeHandler);
-    // Add listener for hue change button
-    const hueBtn = this.shadowRoot.getElementById("change-hue");
-    hueBtn.addEventListener("click", this.changeHue);
     // Apply persisted hue/radius/chroma if available
     const storedHue = localStorage.getItem('brandHue');
     if (storedHue) {
@@ -66,11 +47,6 @@ class SiteSettings extends HTMLElement {
       document.documentElement.style.setProperty('--base-radius', storedRadius + 'px');
     }
 
-    const storedDataTheme = localStorage.getItem('dataTheme') || 'balanced';
-    const themeStyleInput = this.shadowRoot.querySelector(`input[name="dataTheme"][value="${storedDataTheme}"]`);
-    if (themeStyleInput) themeStyleInput.checked = true;
-    this.updateDataTheme(storedDataTheme);
-    this.shadowRoot.getElementById('data-theme-selector').addEventListener('change', this.dataThemeChangeHandler);
 
     // Apply persisted text heading width if available
     const storedTextHeadingWidth = localStorage.getItem('textHeadingWidth');
@@ -101,48 +77,8 @@ class SiteSettings extends HTMLElement {
     }
   }
 
-  dataThemeChangeHandler(event) {
-    if (event.target.name === "dataTheme") {
-      this.updateDataTheme(event.target.value);
-    }
-  }
 
-  updateDataTheme(themeStyle) {
-    localStorage.setItem('dataTheme', themeStyle);
-    if (themeStyle) {
-      document.documentElement.setAttribute('data-theme', themeStyle);
-    } else {
-      document.documentElement.removeAttribute('data-theme');
-    }
-  }
 
-  changeHue() {
-    // Maximum hue shift in degrees
-    const hueLimit = 90; // change this value to adjust the limit
-    const currentHue = parseInt(localStorage.getItem('brandHue') || '0', 10);
-    const deltaHue = Math.floor(Math.random() * (hueLimit * 2 + 1)) - hueLimit;
-    const randomHue = (currentHue + deltaHue + 360) % 360;
-    document.documentElement.style.setProperty("--base-hue", randomHue + "deg");
-
-    // Random radius 0–8px
-    const randomRadius = Math.floor(Math.random() * 9);
-    document.documentElement.style.setProperty("--base-radius", randomRadius + "px");
-
-    // Random text heading grade 0–100 (unitless)
-    const randomTextHeadingGrade = Math.floor(Math.random() * 101);
-    document.documentElement.style.setProperty('--text-heading-grade', randomTextHeadingGrade);
-    localStorage.setItem('textHeadingGrade', randomTextHeadingGrade);
-
-    // Random contrast 0.50–1.50
-    const randomContrast = (Math.random() + 0.5).toFixed(2);
-    document.documentElement.style.setProperty('--contrast', randomContrast);
-    localStorage.setItem('contrast', randomContrast);
-
-    console.log(`--base-hue set to: ${randomHue}deg`);
-    // Persist random values so they survive page loads
-    localStorage.setItem('brandHue', randomHue);
-    localStorage.setItem('baseRadius', randomRadius);
-  }
 }
 
 customElements.define("site-settings", SiteSettings);

--- a/assets/js/components/theme-control.js
+++ b/assets/js/components/theme-control.js
@@ -59,12 +59,16 @@ class ThemeControl extends HTMLElement {
   }
 
   connectedCallback() {
-    document.documentElement.style.setProperty('--base-hue', '0deg');
-    document.documentElement.style.setProperty('--stimulation-level', '0.50');
+    const storedHue  = parseFloat(localStorage.getItem('brandHue')) || 0;
+    const storedStim = parseFloat(localStorage.getItem('stimulationLevel')) || 0.50;
     this.slider.addEventListener('pointerdown', this.onDown);
     window.addEventListener('pointermove', this.onMove);
     window.addEventListener('pointerup',   this.onUp);
-    this.updateHandle(0, 0);
+    const x = storedHue / 360;
+    const minS = 0.5, maxS = 0.9;
+    const y = (storedStim - minS) / (maxS - minS);
+    this.updateHandle(x, y);
+    this.updateVariables(x, y);
   }
 
   disconnectedCallback() {
@@ -95,11 +99,13 @@ class ThemeControl extends HTMLElement {
   }
 
   updateVariables(x, y) {
-    const hue  = Math.round(x * 360) + 'deg';
+    const hueValue = Math.round(x * 360);
     const minS = 0.5, maxS = 0.9;
     const stim = (y * (maxS - minS) + minS).toFixed(2);
-    document.documentElement.style.setProperty('--base-hue', hue);
+    document.documentElement.style.setProperty('--base-hue', hueValue + 'deg');
     document.documentElement.style.setProperty('--stimulation-level', stim);
+    localStorage.setItem('brandHue', hueValue);
+    localStorage.setItem('stimulationLevel', stim);
   }
 }
 

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -4,6 +4,7 @@
     const theme = localStorage.getItem('myCustomTheme') || 'light dark'; // Default to 'light' if not set
     const highContrast = localStorage.getItem('highContrast') === 'true';
     const selectedColorHue = localStorage.getItem('brandHue') || '230';
+    const selectedStimulation = localStorage.getItem('stimulationLevel');
     // Retrieve persisted radius and custom theme
     const selectedRadius = localStorage.getItem('baseRadius');
 
@@ -21,8 +22,11 @@
       document.documentElement.dataset.mode = 'normal';
     }
 
-    // Set the hue
+    // Set the hue and stimulation level
     document.documentElement.style.setProperty('--base-hue', selectedColorHue + 'deg');
+    if (selectedStimulation) {
+      document.documentElement.style.setProperty('--stimulation-level', selectedStimulation);
+    }
     // Apply persisted radius if available
     if (selectedRadius) {
       document.documentElement.style.setProperty('--base-radius', selectedRadius + 'px');

--- a/experiments.html
+++ b/experiments.html
@@ -111,9 +111,9 @@
             <span class="title">Resources</span>
           </a>
         </li>
-      </menu>
-
-      <site-settings></site-settings>
+        </menu>
+        <theme-control></theme-control>
+        <site-settings></site-settings>
 
     </nav>
 

--- a/fundamentals/simplicity.html
+++ b/fundamentals/simplicity.html
@@ -96,6 +96,7 @@
             <span class="title">Resources</span>
           </a></li>
       </menu>
+<theme-control></theme-control>
 <site-settings></site-settings>
      
 

--- a/index.html
+++ b/index.html
@@ -94,6 +94,7 @@
             <span class="title">Resources</span>
           </a></li>
       </menu>
+      <theme-control></theme-control>
       <site-settings></site-settings>
     </nav>
 

--- a/resources.html
+++ b/resources.html
@@ -101,6 +101,7 @@
             <span class="title">Resources</span>
           </a></li>
       </menu>
+      <theme-control></theme-control>
       <site-settings></site-settings>
     </nav>
 


### PR DESCRIPTION
## Summary
- persist theme values with localStorage in `theme-control`
- load saved stimulation level on page init in `index.js`
- simplify `site-settings` component
- place `<theme-control>` in every sidebar

## Testing
- `npm test` *(fails: Error: no test specified)*