### PR TITLE
Create reusable navigation component

### DIFF
--- a/assets/js/components/index.js
+++ b/assets/js/components/index.js
@@ -6,3 +6,4 @@ import './resource-card.js';
 import './icon-card.js';
 import './color-changer.js';
 import './theme-control.js';
+import './navigation.js';

--- a/assets/js/components/navigation.js
+++ b/assets/js/components/navigation.js
@@ -1,0 +1,69 @@
+class SiteNavigation extends HTMLElement {
+  constructor() {
+    super();
+  }
+
+  connectedCallback() {
+    if (!this.rendered) {
+      this.render();
+      this.rendered = true;
+    }
+  }
+
+  render() {
+    this.innerHTML = `
+    <nav class="sidebar">
+      <h2 class="site-title"><a href="/">Ben Jennings</a></h2>
+      <div class="active-box"></div>
+      <menu>
+        <li><a class="nav-item item1" href="/">
+            <span class="icon" role="img" aria-hidden="true">waving_hand</span>
+            <span class="title">Home</span>
+          </a></li>
+        <li><a class="nav-item item2" href="/fundamentals/">
+            <span class="icon" role="img" aria-hidden="true">psychology</span>
+            <span class="title">Fundamentals</span>
+          </a></li>
+        <li><a class="nav-item item3" href="/designs.html">
+            <span class="icon" role="img" aria-hidden="true">web</span>
+            <span class="title">Designs</span>
+          </a></li>
+        <li><a class="nav-item item4" href="/experiments.html">
+            <span class="icon" role="img" aria-hidden="true">experiment</span>
+            <span class="title">Experiments</span>
+          </a></li>
+        <li><a class="nav-item item5" href="/resources.html">
+            <span class="icon" role="img" aria-hidden="true">folder_open</span>
+            <span class="title">Resources</span>
+          </a></li>
+      </menu>
+      <theme-control></theme-control>
+      <site-settings></site-settings>
+    </nav>`;
+
+    this.setActiveItem();
+  }
+
+  setActiveItem() {
+    const path = window.location.pathname;
+    let selector = null;
+    if (path === '/' || path === '/index.html') {
+      selector = '.item1';
+    } else if (path.startsWith('/fundamentals')) {
+      selector = '.item2';
+    } else if (path === '/designs.html') {
+      selector = '.item3';
+    } else if (path === '/experiments.html') {
+      selector = '.item4';
+    } else if (path === '/resources.html') {
+      selector = '.item5';
+    }
+
+    if (selector) {
+      const link = this.querySelector(selector);
+      if (link) link.classList.add('active');
+    }
+  }
+}
+
+customElements.define('site-navigation', SiteNavigation);

--- a/designs.html
+++ b/designs.html
@@ -75,44 +75,7 @@
 
 <body>
   <div id="page-container" class="page-container">
-    <nav class="sidebar">
-      <h2 class="site-title"><a href="/">Ben Jennings</a></h2>
-      <div class="active-box"></div>
-      <menu>
-        <li>
-          <a class="nav-item item1" href="/">
-            <span class="icon" role="img" aria-hidden="true">waving_hand</span>
-            <span class="title">Home</span>
-          </a>
-        </li>
-        <li>
-          <a class="nav-item item2" href="/fundamentals/">
-            <span class="icon" role="img" aria-hidden="true">psychology</span>
-            <span class="title">Fundamentals</span>
-          </a>
-        </li>
-        <li>
-          <a class="nav-item item3 active" href="/designs.html">
-            <span class="icon" role="img" aria-hidden="true">web</span>
-            <span class="title">Designs</span>
-          </a>
-        </li>
-        <li>
-          <a class="nav-item item4" href="/experiments.html">
-            <span class="icon" role="img" aria-hidden="true">experiment</span>
-            <span class="title">Experiments</span>
-          </a>
-        </li>
-        <li>
-          <a class="nav-item item5" href="/resources.html">
-            <span class="icon" role="img" aria-hidden="true">folder_open</span>
-            <span class="title">Resources</span>
-          </a>
-        </li>
-      </menu>
- <theme-control></theme-control>
-      <site-settings></site-settings>
-    </nav>
+    <site-navigation></site-navigation>
 
 
     <header class="page-title">

--- a/experiments.html
+++ b/experiments.html
@@ -77,45 +77,7 @@
 
 <body>
   <div id="page-container" class="page-container">
-    <nav class="sidebar">
-      <h2 class="site-title"><a href="/">Ben Jennings</a></h2>
-      <div class="active-box"></div>
-      <menu>
-        <li>
-          <a class="nav-item" href="/">
-            <span class="icon" role="img" aria-hidden="true">waving_hand</span>
-            <span class="title">Home</span>
-          </a>
-        </li>
-        <li>
-          <a class="nav-item item2" href="/fundamentals/">
-            <span class="icon" role="img" aria-hidden="true">psychology</span>
-            <span class="title">Fundamentals</span>
-          </a>
-        </li>
-        <li>
-          <a class="nav-item item3" href="/designs.html">
-            <span class="icon" role="img" aria-hidden="true">web</span>
-            <span class="title">Designs</span>
-          </a>
-        </li>
-        <li>
-          <a class="nav-item item4 active" href="/experiments.html">
-            <span class="icon" role="img" aria-hidden="true">experiment</span>
-            <span class="title">Experiments</span>
-          </a>
-        </li>
-        <li>
-          <a class="nav-item item5" href="/resources.html">
-            <span class="icon" role="img" aria-hidden="true">folder_open</span>
-            <span class="title">Resources</span>
-          </a>
-        </li>
-        </menu>
-        <theme-control></theme-control>
-        <site-settings></site-settings>
-
-    </nav>
+    <site-navigation></site-navigation>
 
     <main>
       <header class="page-title">

--- a/fundamentals/index.html
+++ b/fundamentals/index.html
@@ -71,36 +71,7 @@
 
 <body>
   <div id="page-container" class="page-container">
-    <nav class="sidebar">
-      <h2 class="site-title"><a href="/">Ben Jennings</a></h2>
-      <div class="active-box"></div>
-      <menu>
-        <li><a class="nav-item item1" href="/">
-            <span class="icon" role="presentation" aria-hidden="true">waving_hand</span>
-            <span class="title">Home</span>
-          </a></li>
-        <li><a class="nav-item item2 active" href="/fundamentals/">
-            <span class="icon" role="presentation" aria-hidden="true">psychology</span>
-            <span class="title">Fundamentals</span>
-          </a></li>
-        <li><a class="nav-item item3 " href="/designs.html">
-            <span class="icon" role="presentation" aria-hidden="true">web</span>
-            <span class="title">Designs</span>
-          </a></li>
-        <li><a class="nav-item item4 " href="/experiments.html">
-            <span class="icon" role="presentation" aria-hidden="true">experiment</span>
-            <span class="title">Experiments</span>
-          </a></li>
-        <li><a class="nav-item item5" href="/resources.html">
-            <span class="icon" role="presentation" aria-hidden="true">folder_open</span>
-            <span class="title">Resources</span>
-          </a></li>
-      </menu>
-       <theme-control></theme-control>
-<site-settings></site-settings>
-
-
-    </nav>
+    <site-navigation></site-navigation>
     
 
 

--- a/fundamentals/simplicity.html
+++ b/fundamentals/simplicity.html
@@ -71,36 +71,7 @@
 
 <body>
   <div id="page-container" class="page-container detail-page">
-    <nav class="sidebar">
-      <h2 class="site-title"><a href="/">Ben Jennings</a></h2>
-      <div class="active-box"></div>
-      <menu>
-        <li><a class="nav-item item1" href="/">
-            <span class="icon" role="presentation" aria-hidden="true">waving_hand</span>
-            <span class="title">Home</span>
-          </a></li>
-        <li><a class="nav-item item2 active" href="/fundamentals/">
-            <span class="icon" role="presentation" aria-hidden="true">psychology</span>
-            <span class="title">Fundamentals</span>
-          </a></li>
-        <li><a class="nav-item item3 " href="/designs.html">
-            <span class="icon" role="presentation" aria-hidden="true">web</span>
-            <span class="title">Designs</span>
-          </a></li>
-        <li><a class="nav-item item4 " href="/experiments.html">
-            <span class="icon" role="presentation" aria-hidden="true">experiment</span>
-            <span class="title">Experiments</span>
-          </a></li>
-        <li><a class="nav-item item5" href="/resources.html">
-            <span class="icon" role="presentation" aria-hidden="true">folder_open</span>
-            <span class="title">Resources</span>
-          </a></li>
-      </menu>
-<theme-control></theme-control>
-<site-settings></site-settings>
-     
-
-    </nav>
+    <site-navigation></site-navigation>
 
   
      

--- a/index.html
+++ b/index.html
@@ -69,34 +69,7 @@
 
 <body>
   <div id="page-container" class="page-container hero-page">
-    <nav class="sidebar">
-      <h2 class="site-title"><a href="/">Ben Jennings</a></h2>
-      <div class="active-box"></div>
-      <menu>
-        <li><a class="nav-item item1 active" href="/">
-            <span class="icon" role="img" aria-hidden="true">waving_hand</span>
-            <span class="title">Home</span>
-          </a></li>
-        <li><a class="nav-item item2" href="/fundamentals/">
-            <span class="icon" role="img" aria-hidden="true">psychology</span>
-            <span class="title">Fundamentals</span>
-          </a></li>
-        <li><a class="nav-item item3 " href="/designs.html">
-            <span class="icon" role="img" aria-hidden="true">web</span>
-            <span class="title">Designs</span>
-          </a></li>
-        <li><a class="nav-item item4 " href="/experiments.html">
-            <span class="icon" role="img" aria-hidden="true">experiment</span>
-            <span class="title">Experiments</span>
-          </a></li>
-        <li><a class="nav-item item5" href="/resources.html">
-            <span class="icon" role="img" aria-hidden="true">folder_open</span>
-            <span class="title">Resources</span>
-          </a></li>
-      </menu>
-      <theme-control></theme-control>
-      <site-settings></site-settings>
-    </nav>
+    <site-navigation></site-navigation>
 
     <main>
       <div class="welcome">

--- a/resources.html
+++ b/resources.html
@@ -75,35 +75,7 @@
 
 <body>
   <div id="page-container" class="page-container">
-    <nav class="sidebar">
-      <h2 class="site-title"><a href="/">Ben Jennings</a></h2>
-      <div class="active-box"></div>
-
-      <menu>
-        <li><a class="nav-item item1" href="/">
-            <span class="icon" role="img" aria-hidden="true">waving_hand</span>
-            <span class="title">Home</span>
-          </a></li>
-        <li><a class="nav-item item2" href="/fundamentals/">
-            <span class="icon" role="img" aria-hidden="true">psychology</span>
-            <span class="title">Fundamentals</span>
-          </a></li>
-        <li><a class="nav-item item3 " href="/designs.html">
-            <span class="icon" role="img" aria-hidden="true">web</span>
-            <span class="title">Designs</span>
-          </a></li>
-        <li><a class="nav-item item4 " href="/experiments.html">
-            <span class="icon" role="img" aria-hidden="true">experiment</span>
-            <span class="title">Experiments</span>
-          </a></li>
-        <li><a class="nav-item item5 active" href="/resources.html">
-            <span class="icon" role="img" aria-hidden="true">folder_open</span>
-            <span class="title">Resources</span>
-          </a></li>
-      </menu>
-      <theme-control></theme-control>
-      <site-settings></site-settings>
-    </nav>
+    <site-navigation></site-navigation>
 
     <main>
       <header class="page-title">


### PR DESCRIPTION
## Summary
- add `<site-navigation>` custom element to centralize sidebar markup
- import navigation component
- replace per-page nav markup with `<site-navigation>`

## Testing
- `npm test` *(fails: Error: no test specified)*