### PR TITLE
Position theme FAB

### DIFF
--- a/assets/css/components/navigation.css
+++ b/assets/css/components/navigation.css
@@ -198,6 +198,7 @@ theme-slider {
 @media screen and (max-width: 800px),
 (max-height:500px) {
   .sidebar {
+    anchor-name: --bottom-nav;
     height: fit-content;
     width: 100%;
     flex-shrink: 0;

--- a/assets/css/global/page.css
+++ b/assets/css/global/page.css
@@ -269,9 +269,17 @@ figure {
 
   theme-control {
     position: fixed;
-    top: 24px;
-    left: 24px;
+    position-anchor: --bottom-nav;
+    bottom: calc(anchor(top) + 24px);
+    right: 24px;
     width: fit-content;
+  }
+
+  @supports not (position-anchor: --bottom-nav) {
+    theme-control {
+      bottom: calc(var(--bottom-nav-height) + 24px);
+      right: 24px;
+    }
   }
 
 

--- a/assets/css/vars.css
+++ b/assets/css/vars.css
@@ -57,6 +57,7 @@
   ------------------------------------*/
   --viewport-lg: 800px;
   --dialog-width: clamp(300px, 80dvw, 1200px);
+  --bottom-nav-height: 80px;
 
   /*------------------------------------
     Typography Scale


### PR DESCRIPTION
## Summary
- move theme control button to bottom right on mobile
- anchor popover to top-left of the button
- add anchor fallback for browsers without anchor positioning
- expose bottom nav anchor name and variable

## Testing
- `npm test` *(fails: Error: no test specified)*