### PR TITLE
Fix mobile scrolling

### DIFF
--- a/assets/css/global/page.css
+++ b/assets/css/global/page.css
@@ -78,7 +78,7 @@ body {
 .page-container {
 
   box-sizing: border-box;
-  height: 100dvh;
+  min-height: 100dvh;
   display: grid;
   grid-template-columns: clamp(350px, 20dvw, 400px) 1fr;
   grid-template-rows: auto minmax(0, 1fr);
@@ -87,7 +87,7 @@ body {
     "sidebar content"
   ;
   perspective: 1500px;
-  height: 100dvh;
+  min-height: 100dvh;
   /* lock container to viewport height */
 
 
@@ -235,8 +235,7 @@ figure {
 @media screen and (max-width: 800px),
 (max-height:500px) {
   body {
-    height: 100dvh;
-    ;
+    min-height: 100dvh;
   }
 
   main {
@@ -246,7 +245,7 @@ figure {
     padding: 12px;
     padding-left: env(safe-area-inset-left);
     padding-right: env(safe-area-inset-right);
-    overflow: clip;
+    overflow: auto;
   }
 
   .main-content {

--- a/assets/css/global/typography.css
+++ b/assets/css/global/typography.css
@@ -19,7 +19,7 @@ body {
   padding: 0;
   color: var(--foreground-primary);
   background-color: var(--background-page);
-  height: 100dvh;
+  min-height: 100dvh;
   font-family: var(--text-body-font-family);
   font-weight: var(--text-body-weight);
   box-sizing: border-box;


### PR DESCRIPTION
## Summary
- allow the body and page container to grow beyond the viewport
- enable scrolling in main on small screens

## Testing
- `npm test` *(fails: no test specified)*