### PR TITLE
Fix mobile nav placement

### DIFF
--- a/assets/css/components/navigation.css
+++ b/assets/css/components/navigation.css
@@ -200,6 +200,7 @@ theme-slider {
 (max-height:500px) {
   .sidebar {
     anchor-name: --bottom-nav;
+    position: fixed;
     height: fit-content;
     width: 100%;
     flex-shrink: 0;


### PR DESCRIPTION
## Summary
- make the navigation bar fixed to the bottom on small screens

## Testing
- `npm test` *(fails: no test specified)*