### PR TITLE
Fix detail view transition container

### DIFF
--- a/assets/js/view-transition.js
+++ b/assets/js/view-transition.js
@@ -34,7 +34,8 @@ function applyViewTransitionNames() {
   // Assign name to detail page container if applicable
   if (document.body.classList.contains('detail-page')) {
     const slug = getSlug(location.pathname);
-    const container = document.querySelector('main');
+    const container =
+      document.querySelector('.page-detail') || document.querySelector('main');
     if (container) {
       // Include a generic "detail" name so CSS can target all detail pages
       container.style.viewTransitionName = `vt-${slug}, detail`;


### PR DESCRIPTION
## Summary
- fix view transition for detail pages by targeting `.page-detail` instead of `<main>`

## Testing
- `npm test` *(fails: no test specified)*