### PR TITLE
Refactor view transitions

### DIFF
--- a/assets/css/animations/view-transition.css
+++ b/assets/css/animations/view-transition.css
@@ -5,12 +5,12 @@
 
 
 site-navigation{
-  view-transition-name:nav;
+  view-transition-name:none;
 
 }
 
 site-settings{
-  view-transition-name:settings;
+  view-transition-name:none;
 
 }
 
@@ -59,7 +59,7 @@ html::view-transition-group(*) {
 
 
 main {
-  view-transition-name: main;
+  view-transition-name: none;
 }
 
 ::view-transition-new(main){
@@ -81,7 +81,7 @@ main {
 
 
 .page-items> :nth-child(1) {
-  view-transition-name: item1;
+  view-transition-name: none;
 }
 
 ::view-transition-group(item1) {
@@ -89,7 +89,7 @@ main {
 }
 
 .page-items> :nth-child(2) {
-  view-transition-name: item2;
+  view-transition-name: none;
 }
 
 ::view-transition-group(item2) {
@@ -97,7 +97,7 @@ main {
 }
 
 .page-items> :nth-child(3) {
-  view-transition-name: item3;
+  view-transition-name: none;
 }
 
 ::view-transition-group(item3) {
@@ -106,7 +106,7 @@ main {
 
 
 .page-items> :nth-child(4) {
-  view-transition-name: item4;
+  view-transition-name: none;
 }
 
 ::view-transition-group(item4) {
@@ -114,7 +114,7 @@ main {
 }
 
 .page-items> :nth-child(5) {
-  view-transition-name: item5;
+  view-transition-name: none;
 }
 
 ::view-transition-group(item5) {
@@ -122,7 +122,7 @@ main {
 }
 
 .page-items> :nth-child(6) {
-  view-transition-name: item6;
+  view-transition-name: none;
 }
 
 ::view-transition-group(item6) {
@@ -153,7 +153,7 @@ main {
 
 
 :is(.welcome, .page-title) {
-  view-transition-name: content;
+  view-transition-name: none;
 }
 
 


### PR DESCRIPTION
## Summary
- use `pageswap` event to manage view transitions
- remove default transition labels from CSS so they can be added dynamically

## Testing
- `npm test` *(fails: Error: no test specified)*