### PR TITLE
Refactor view transitions

### DIFF
--- a/assets/css/animations/view-transition.css
+++ b/assets/css/animations/view-transition.css
@@ -5,12 +5,12 @@
 
 
 site-navigation{
-  view-transition-name:nav;
+  view-transition-name:none;
 
 }
 
 site-settings{
-  view-transition-name:settings;
+  view-transition-name:none;
 
 }
 
@@ -59,7 +59,7 @@ html::view-transition-group(*) {
 
 
 main {
-  view-transition-name: main;
+  view-transition-name: none;
 }
 
 ::view-transition-new(main){
@@ -81,7 +81,7 @@ main {
 
 
 .page-items> :nth-child(1) {
-  view-transition-name: item1;
+  view-transition-name: none;
 }
 
 ::view-transition-group(item1) {
@@ -89,7 +89,7 @@ main {
 }
 
 .page-items> :nth-child(2) {
-  view-transition-name: item2;
+  view-transition-name: none;
 }
 
 ::view-transition-group(item2) {
@@ -97,7 +97,7 @@ main {
 }
 
 .page-items> :nth-child(3) {
-  view-transition-name: item3;
+  view-transition-name: none;
 }
 
 ::view-transition-group(item3) {
@@ -106,7 +106,7 @@ main {
 
 
 .page-items> :nth-child(4) {
-  view-transition-name: item4;
+  view-transition-name: none;
 }
 
 ::view-transition-group(item4) {
@@ -114,7 +114,7 @@ main {
 }
 
 .page-items> :nth-child(5) {
-  view-transition-name: item5;
+  view-transition-name: none;
 }
 
 ::view-transition-group(item5) {
@@ -122,7 +122,7 @@ main {
 }
 
 .page-items> :nth-child(6) {
-  view-transition-name: item6;
+  view-transition-name: none;
 }
 
 ::view-transition-group(item6) {
@@ -153,7 +153,7 @@ main {
 
 
 :is(.welcome, .page-title) {
-  view-transition-name: content;
+  view-transition-name: none;
 }
 
 

--- a/assets/js/view-transition.js
+++ b/assets/js/view-transition.js
@@ -1,20 +1,3 @@
-if ('startViewTransition' in document) {
-  document.addEventListener('click', (event) => {
-    const link = event.target.closest('a');
-    if (!link) return;
-    // Only handle same-origin navigations without target="_blank" or download
-    const url = new URL(link.href, location.href);
-    if (url.origin !== location.origin) return;
-    if (link.target && link.target !== '_self') return;
-    if (link.hasAttribute('download')) return;
-    if (url.pathname === location.pathname && !url.hash) return;
-    event.preventDefault();
-    document.startViewTransition(() => {
-      location.href = link.href;
-    });
-  });
-}
-
 function getSlug(pathname) {
   const segments = pathname.split('/').filter(Boolean);
   let last = segments.pop() || '';
@@ -22,26 +5,79 @@ function getSlug(pathname) {
   return last.replace(/\.html$/, '');
 }
 
-function applyViewTransitionNames() {
-  // Assign names to cards linking to detail pages
-  const cards = document.querySelectorAll('.page-items a.card[href]');
-  cards.forEach((card) => {
-    const url = new URL(card.getAttribute('href'), location.href);
-    const slug = getSlug(url.pathname);
-    card.style.viewTransitionName = `vt-${slug}`;
-  });
-
-  // Assign name to detail page container if applicable
-  if (document.body.classList.contains('detail-page')) {
-    const slug = getSlug(location.pathname);
-    const container =
-      document.querySelector('.page-detail') || document.querySelector('main');
-    if (container) {
-      // Include a generic "detail" name so CSS can target all detail pages
-      container.style.viewTransitionName = `vt-${slug}, detail`;
-    }
-  }
+function isDesignList(url) {
+  return url ? url.endsWith('/designs.html') : false;
 }
 
-document.addEventListener('DOMContentLoaded', applyViewTransitionNames);
+function isDesignDetail(url) {
+  return /\/designs\/[^/]+\.html$/.test(url || '');
+}
 
+const cases = [
+  {
+    match: (from, to) => isDesignList(from) && isDesignDetail(to),
+    select: (_from, to) => {
+      const slug = getSlug(new URL(to, location.href).pathname);
+      const card = document.querySelector(
+        `.page-items a.card[href$='${slug}.html']`
+      );
+      const container =
+        document.querySelector('.page-detail') || document.querySelector('main');
+      return [card, container];
+    },
+    names: (_from, to) => {
+      const slug = getSlug(new URL(to, location.href).pathname);
+      return [`vt-${slug}`, `vt-${slug}, detail`];
+    },
+  },
+  {
+    match: (from, to) => isDesignDetail(from) && isDesignList(to),
+    select: (from) => {
+      const slug = getSlug(new URL(from, location.href).pathname);
+      const card = document.querySelector(
+        `.page-items a.card[href$='${slug}.html']`
+      );
+      const container =
+        document.querySelector('.page-detail') || document.querySelector('main');
+      // container exists on the detail page, card on the list page
+      return [container, card];
+    },
+    names: (from) => {
+      const slug = getSlug(new URL(from, location.href).pathname);
+      return [`vt-${slug}, detail`, `vt-${slug}`];
+    },
+  },
+  {
+    match: (_, to) => isDesignDetail(to),
+    select: (_from, to) => {
+      const container =
+        document.querySelector('.page-detail') || document.querySelector('main');
+      return [container];
+    },
+    names: (_from, to) => {
+      const slug = getSlug(new URL(to, location.href).pathname);
+      return [`vt-${slug}, detail`];
+    },
+  },
+];
+
+window.addEventListener('pageswap', async (e) => {
+  if (!e.viewTransition) return;
+
+  const fromUrl = e.activation.from?.url || null;
+  const toUrl = e.activation.entry.url;
+
+  for (const c of cases) {
+    if (!c.match(fromUrl, toUrl)) continue;
+    const elems = c.select(fromUrl, toUrl).filter(Boolean);
+    const names = typeof c.names === 'function' ? c.names(fromUrl, toUrl) : c.names;
+    elems.forEach((el, i) => {
+      el.style.viewTransitionName = names[i] || `anon-${i}`;
+    });
+    await e.viewTransition.finished;
+    elems.forEach((el) => {
+      el.style.viewTransitionName = 'none';
+    });
+    break;
+  }
+});


### PR DESCRIPTION
## Summary
- use `pageswap` event to manage view transitions
- remove default transition labels from CSS so they can be added dynamically
- share slug-based view transition names between list cards and detail pages

## Testing
- `npm test` *(fails: Error: no test specified)*
