### PR TITLE
Refactor foreground colors

### DIFF
--- a/src/assets/styles/base/page.css
+++ b/src/assets/styles/base/page.css
@@ -42,7 +42,7 @@ select {
   top: -40px;
   left: 6px;
   background: var(--color-background-base-emphasis);
-  color: var(--color-foreground-onEmphasis);
+  color: var(--color-text-onEmphasis);
   padding: 8px;
   border-radius: 4px;
   text-decoration: none;
@@ -59,7 +59,7 @@ select {
 
 ::selection {
   background: var(--color-background-color2-secondary);
-  color: var(--color-foreground-color2);
+  color: var(--color-text-color2);
   text-decoration: underline;
   text-decoration-color: var(--color-border-base-emphasis);
 }
@@ -148,7 +148,7 @@ padding: 4dvw;
   scroll-snap-align: top;
   z-index: 2;
   margin-top: calc(20cqh - 40px);
-  color: var(--color-foreground-primary);
+  color: var(--color-text-primary);
   display: flex;
   gap: var(--spacing-md);
   flex-direction: column;
@@ -178,7 +178,7 @@ padding: 4dvw;
 
 .post {
   background-color: var(--color-background-page);
-  color: var(--color-foreground-color4);
+  color: var(--color-text-color4);
  padding: 4dvw;
  margin-inline: auto;
   display: flex;
@@ -205,7 +205,7 @@ padding: 4dvw;
 
 .post-header {
   background-color: var(--color-background-color2);
-  color: var(--color-foreground-color4);
+  color: var(--color-text-color4);
   padding: var(--spacing-xxl);
   border-bottom: 1px solid var(--color-border-primary);
   display: flex;
@@ -215,25 +215,25 @@ padding: 4dvw;
 
   &.color1 {
     background-color: var(--color-background-base);
-    color: var(--color-foreground-base);
+    color: var(--color-text-base);
     border-color: var(--color-border-base);
   }
 
   &.color2 {
     background-color: var(--color-background-color2);
-    color: var(--color-foreground-color2);
+    color: var(--color-text-color2);
     border-color: var(--color-border-color2);
   }
 
   &.color3 {
     background-color: var(--color-background-color3);
-    color: var(--color-foreground-color3);
+    color: var(--color-text-color3);
     border-color: var(--color-border-color3);
   }
 
   &.color4 {
     background-color: var(--color-background-color4);
-    color: var(--color-foreground-color4);
+    color: var(--color-text-color4);
     border-color: var(--color-border-color4);
   }
 
@@ -287,7 +287,7 @@ padding: 4dvw;
   .icon-group .icon {
     font-family: var(--icon-font-family);
     font-size: 46px;
-    color: var(--color-foreground-onEmphasis);
+    color: var(--color-icon-onEmphasis);
     font-weight: 700;
     line-height: 1;
   }
@@ -304,7 +304,7 @@ figure {
   figcaption {
     text-align: center;
     font-size: var(--text-body-md-size);
-    color: var(--color-foreground-secondary);
+    color: var(--color-text-secondary);
     margin-block: var(--spacing-sm);
 
 
@@ -341,7 +341,7 @@ figure {
   background-color: var(--color-background-page);
   scroll-snap-align: top;
   z-index: 2;
-  color: var(--color-foreground-primary);
+  color: var(--color-text-primary);
   width: 100%;
   max-width: 700px;
   top: 0px;

--- a/src/assets/styles/base/typography.css
+++ b/src/assets/styles/base/typography.css
@@ -17,7 +17,7 @@ p {
 body {
   margin: 0;
   padding: 0;
-  color: var(--color-foreground-primary);
+  color: var(--color-text-primary);
   background-color: var(--color-background-page);
   min-height: 100dvh;
   font-family: var(--text-body-font-family);
@@ -65,7 +65,7 @@ u {
   }
 
   &.secondary {
-    color: var(--color-foreground-secondary);
+    color: var(--color-text-secondary);
   }
 }
 
@@ -97,7 +97,7 @@ u {
   }
 
   &.secondary {
-    color: var(--color-foreground-secondary);
+    color: var(--color-text-secondary);
   }
 }
 
@@ -138,7 +138,7 @@ transition-timing-function: var(--timing-decelerate);
   }
 
   &.brand {
-    color: var(--color-foreground-base);
+    color: var(--color-icon-base);
   }
 }
 

--- a/src/assets/styles/base/vars.css
+++ b/src/assets/styles/base/vars.css
@@ -467,17 +467,6 @@
   --color-background-color4-emphasis: light-dark(var(--color-color4-30), var(--color-color4-70));
   --color-background-backdrop: light-dark(var(--color-gray-20-alpha), var(--color-gray-50-alpha));
 
-  /* foreground colors */
-  --color-foreground-primary: light-dark(var(--color-gray-95), var(--color-gray-5));
-  --color-foreground-secondary: light-dark(var(--color-gray-80), var(--color-gray-10));
-  --color-foreground-tertiary: light-dark(var(--color-gray-60), var(--color-gray-20));
-  --color-foreground-base: light-dark(var(--color-color1-80), var(--color-color1-20));
-  --color-foreground-base-secondary: light-dark(var(--color-color1-60), var(--color-color1-30));
-  --color-foreground-onBrand: light-dark(var(--color-color1-50), var(--color-color1-10));
-  --color-foreground-color2: light-dark(var(--color-color2-95), var(--color-color2-20));
-  --color-foreground-color3: light-dark(var(--color-color3-95), var(--color-color3-20));
-  --color-foreground-color4: light-dark(var(--color-color4-95), var(--color-color4-20));
-  --color-foreground-onEmphasis: light-dark(white, white);
 
   /* text colors */
   --color-text-primary: light-dark(var(--color-gray-95), var(--color-gray-5));
@@ -545,13 +534,6 @@
   --color-background-color2-secondary: light-dark(var(--color-color2-10), var(--color-color2-80));
   --color-background-color2-emphasis: light-dark(var(--color-color2-60), var(--color-color2-50));
   --color-background-backdrop: light-dark(var(--color-gray-80-alpha), var(--color-gray-30-alpha));
-  --color-foreground-primary: light-dark(var(--color-gray-95), var(--color-gray-5));
-  --color-foreground-secondary: light-dark(var(--color-gray-80), var(--color-gray-10));
-  --color-foreground-base: light-dark(var(--color-color1-60), var(--color-color1-20));
-  --color-foreground-onBrand: light-dark(var(--color-white), var(--color-white));
-  --color-foreground-base-secondary: light-dark(var(--color-color1-60), var(--color-color1-20));
-  --color-foreground-color2: light-dark(var(--color-color2-10), var(--color-color2-5));
-  --color-foreground-onEmphasis: light-dark(var(--color-white), var(--color-white));
   --color-border-primary: light-dark(var(--color-gray-40), var(--color-gray-40));
   --color-border-primary-hover: light-dark(var(--color-gray-20), var(--color-gray-70));
   --color-border-secondary: light-dark(var(--color-gray-30), var(--color-gray-50));
@@ -574,13 +556,6 @@
     --color-background-color2-secondary: light-dark(var(--color-color2-10), var(--color-color2-80));
     --color-background-color2-emphasis: light-dark(var(--color-color2-60), var(--color-color2-50));
     --color-background-backdrop: light-dark(var(--color-gray-80-alpha), var(--color-gray-30-alpha));
-    --color-foreground-primary: light-dark(var(--color-gray-95), var(--color-gray-5));
-    --color-foreground-secondary: light-dark(var(--color-gray-80), var(--color-gray-10));
-    --color-foreground-base: light-dark(var(--color-color1-60), var(--color-color1-20));
-    --color-foreground-onBrand: light-dark(var(--color-white), var(--color-white));
-    --color-foreground-base-secondary: light-dark(var(--color-color1-60), var(--color-color1-20));
-    --color-foreground-color2: light-dark(var(--color-color2-10), var(--color-color2-5));
-    --color-foreground-onEmphasis: light-dark(var(--color-white), var(--color-white));
     --color-border-primary: light-dark(var(--color-gray-40), var(--color-gray-40));
     --color-border-primary-hover: light-dark(var(--color-gray-20), var(--color-gray-70));
     --color-border-secondary: light-dark(var(--color-gray-30), var(--color-gray-50));

--- a/src/assets/styles/components/badge.css
+++ b/src/assets/styles/components/badge.css
@@ -4,7 +4,7 @@
     text-wrap: nowrap;
     height: 28px;
     background-color: var(--color-background-color2);
-    color: var(--color-foreground-color2);
+    color: var(--color-text-color2);
     display: flex;
     padding: var(--spacing-xs, 4px) var(--spacing-sm, 8px);
     justify-content: center;
@@ -18,11 +18,11 @@
 
     &.secondary {
         background-color: var(--color-background-primary-secondary);
-        color: var(--color-foreground-secondary);
+        color: var(--color-text-secondary);
         border: 1px solid var(--color-border-color2);
     
         span {
-            color: var(--color-foreground-color2)
+            color: var(--color-text-color2)
         }
     
         ::slotted {
@@ -47,7 +47,7 @@
         font-weight: var(--icon-weight-sm);
         aspect-ratio: 1/1;
         width: var(--icon-size-sm);
-        color: var(--color-foreground-color2);
+        color: var(--color-icon-color2);
         font-variation-settings: "FILL" 1, "wght" 400, "GRAD" 0;
     }
     

--- a/src/assets/styles/components/button.css
+++ b/src/assets/styles/components/button.css
@@ -12,7 +12,7 @@
   gap: var(--spacing-xs, 4px);
   font-family: var(--text-font-family);
   font-size: var(--text-body-md-size);
-  color: var(--color-foreground-primary);
+  color: var(--color-text-primary);
   line-height: var(--text-body-md-line-height);
   height: 48px;
   cursor: pointer;
@@ -48,7 +48,7 @@ button:active {
 
 button[variant="brand"] {
   background: var(--color-background-base-emphasis);
-  color: var(--color-foreground-onEmphasis);
+  color: var(--color-text-onEmphasis);
   border: transparent;
 }
 

--- a/src/assets/styles/components/card.css
+++ b/src/assets/styles/components/card.css
@@ -17,7 +17,7 @@
   container-type: inline-size;
   transition: outline 500ms var(--timing-bounce);
   font-variation-settings: "GRAD" 0;
-  color: var(--color-foreground-primary);
+  color: var(--color-text-primary);
   gap: var(--spacing-xl);
   overflow: hidden;
   outline-offset: 0px;
@@ -67,7 +67,7 @@
 
   &.color1 {
     background-color: var(--color-background-base);
-    color: var(--color-foreground-base);
+    color: var(--color-text-base);
     border-color: var(--color-border-base);
     outline-color: var(--color-border-base);
     &.emphasis {
@@ -78,7 +78,7 @@
 
   &.color2 {
     background-color: var(--color-background-color2);
-    color: var(--color-foreground-color2);
+    color: var(--color-text-color2);
     border-color: var(--color-border-color2);
     outline-color: var(--color-border-color2);
     &.emphasis {
@@ -89,7 +89,7 @@
 
   &.color3 {
     background-color: var(--color-background-color3);
-    color: var(--color-foreground-color3);
+    color: var(--color-text-color3);
     border-color: var(--color-border-color3);
     outline-color: var(--color-border-color3);
     &.emphasis {
@@ -100,7 +100,7 @@
 
   &.color4 {
     background-color: var(--color-background-color4);
-    color: var(--color-foreground-color4);
+    color: var(--color-text-color4);
     border-color: var(--color-border-color4);
     outline-color: var(--color-border-color4);
     &.emphasis {
@@ -134,7 +134,7 @@ p {
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  color: var(--color-foreground-base-secondary);
+  color: var(--color-icon-base-secondary);
   user-select: none;
   -webkit-user-select: none;
 }
@@ -167,7 +167,7 @@ p {
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  color: var(--color-foreground-base-secondary);
+  color: var(--color-icon-base-secondary);
   margin-top: calc(-1 * var(--spacing-xxl));
   margin-inline: calc(-1 * var(--spacing-xxl));
   user-select: none;

--- a/src/assets/styles/components/dialog.css
+++ b/src/assets/styles/components/dialog.css
@@ -1,7 +1,7 @@
 dialog {
   margin: auto;
   opacity: 0;
-  color: var(--color-foreground-primary);
+  color: var(--color-text-primary);
   border: 1px solid var(--color-border-primary);
   width: var(--dialog-width);
   min-width: 600px;
@@ -126,7 +126,7 @@ dialog[open]::backdrop {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  color: var(--color-foreground-primary);
+  color: var(--color-text-primary);
   font-size: var(--text-heading-md-size);
   font-weight: var(--text-heading-weight);
 }

--- a/src/assets/styles/components/navigation.css
+++ b/src/assets/styles/components/navigation.css
@@ -58,7 +58,7 @@ site-navigation {
     li {
       &:focus-visible {
         transform: perspective(300px) translateZ(-50px);
-        outline: 2px solid var(--color-foreground-base);
+        outline: 2px solid var(--color-text-base);
         outline-offset: 2px;
       }
     }
@@ -73,7 +73,7 @@ site-navigation {
 
 .nav-item {
   box-sizing: border-box;
-  color: var(--color-foreground-secondary);
+  color: var(--color-text-secondary);
   height: clamp(50px, 10cqh, 80px);
   display: flex;
   padding: var(--spacing-xl, 24px) var(--spacing-lg, 16px);
@@ -106,7 +106,7 @@ site-navigation {
   }
 
   &:focus-visible {
-    outline: 2px solid var(--color-foreground-base);
+    outline: 2px solid var(--color-text-base);
     outline-offset: 2px;
     transform: perspective(300px) translateZ(-50px);
   }
@@ -132,12 +132,12 @@ site-navigation {
 .active {
   transition: none;
   font-variation-settings: 'GRAD' 100;
-  color: var(--color-foreground-emphasis);
+  color: var(--color-text-base);
   background: transparent;
 
   .icon {
     font-variation-settings: "FILL" 1, "GRAD" var(--icon-grade-emphasis);
-    color: var(--color-foreground-base-secondary);
+    color: var(--color-icon-base-secondary);
   }
 }
 

--- a/src/assets/styles/components/radio-buttons.css
+++ b/src/assets/styles/components/radio-buttons.css
@@ -35,7 +35,7 @@
   
 border-radius: calc(var(--radius-md) - var(--spacing-xs) );
   font-size: var(--text-body-md-size);
-  color: var(--color-foreground-primary);
+  color: var(--color-text-primary);
   font-family: var(--text-font-family);
   cursor: pointer;
 flex: 1;
@@ -62,5 +62,5 @@ flex: 1;
 
 .radio-button:has(input:checked) {
   background-color: var(--color-background-base-emphasis);
-  color: var(--color-foreground-color2);
+  color: var(--color-text-color2);
 }

--- a/src/components/resource-card/resource-card.js
+++ b/src/components/resource-card/resource-card.js
@@ -28,7 +28,7 @@
           transition: outline 300ms cubic-bezier(0.46, 1.33, 0.68, 1.58),
             font-variation-settings 300ms cubic-bezier(0.46, 1.33, 0.68, 1.58);
           font-variation-settings: "GRAD" 0;
-          color: var(--color-foreground-primary);
+          color: var(--color-text-primary);
           overflow: hidden;
           outline-offset: 0px;
           anchor-name: --card;
@@ -48,7 +48,7 @@
           flex-direction: column;
           justify-content: center;
           align-items: center;
-          color: var(--color-foreground-color3);
+          color: var(--color-icon-color3);
           user-select: none;
           -webkit-user-select: none;
           container-name:iconbox;

--- a/src/components/settings/settings.js
+++ b/src/components/settings/settings.js
@@ -79,7 +79,7 @@ template.innerHTML = `
     }
     
     .color-item.custom.selected {
-      outline: 2px solid var(--color-foreground-base);
+      outline: 2px solid var(--color-text-base);
     }
     
     .color-item.swatch {
@@ -89,7 +89,7 @@ template.innerHTML = `
     }
     
     .color-item.swatch.selected {
-      outline: 2px solid var(--color-foreground-base);
+      outline: 2px solid var(--color-text-base);
     }
     
     .color-item.custom .icon {
@@ -97,12 +97,12 @@ template.innerHTML = `
       font-size: var(--icon-size-md);
       line-height: 1;
       font-weight: var(--icon-weight-md);
-      color: var(--color-foreground-secondary);
+      color: var(--color-icon-secondary);
       white-space: nowrap;
     }
     
     .color-item.custom.selected .icon {
-      color: var(--color-foreground-onEmphasis);
+      color: var(--color-icon-onEmphasis);
     }
     
     .color-slider {
@@ -218,14 +218,18 @@ template.innerHTML = `
       flex-shrink: 0;
     }
     
-    .segmented-button:not(.active) .icon,
-    .segmented-button:not(.active) .text {
-      color: var(--color-foreground-primary);
+    .segmented-button:not(.active) .icon {
+      color: var(--color-icon-primary);
     }
-    
-    .segmented-button.active .icon,
+    .segmented-button:not(.active) .text {
+      color: var(--color-text-primary);
+    }
+
+    .segmented-button.active .icon {
+      color: var(--color-icon-base);
+    }
     .segmented-button.active .text {
-      color: var(--color-foreground-base);
+      color: var(--color-text-base);
     }
   </style>
   

--- a/src/components/theme-control/theme-control.js
+++ b/src/components/theme-control/theme-control.js
@@ -7,7 +7,7 @@ template.innerHTML = `
     :host { display:flex; flex-direction:column; anchor-name: --theme-button; }
     .picker { display:flex; gap:4px; background-color:var(--color-background-secondary);border-radius:var(--radius-md); padding:8px;justify-items:stretch; margin-bottom:8px; height:40px;}
     .swatch {  flex:1; border-radius:calc(var(--radius-md) - 8px); border:2px solid var(--color-border-primary); cursor:pointer; padding:0; background:transparent; }
-    .swatch.selected { outline:2px solid var(--color-foreground-color2); }
+    .swatch.selected { outline:2px solid var(--color-text-color2); }
     .custom-swatch { background: linear-gradient(45deg, #ff6b6b, #4ecdc4, #45b7d1, #f9ca24, #f0932b); }
     input[type="range"] { flex:1; display:none; }
     input[type="range"].visible { display:block; }


### PR DESCRIPTION
## Summary
- replace deprecated `color-foreground-*` tokens with `color-text-*` and `color-icon-*`
- drop old foreground token definitions
- update components and base styles to use the new semantic colors

## Testing
- `grep -R "color-foreground" -n | wc -l`

------
https://chatgpt.com/codex/tasks/task_b_688b8682b4fc8323b3dc53a1131b7824