### PR TITLE
Simplify navigation component active state handling

### DIFF
--- a/src/assets/styles/components/navigation.css
+++ b/src/assets/styles/components/navigation.css
@@ -96,7 +96,7 @@ site-navigation {
   font-variation-settings: initial;
   font-variation-settings: "GRAD" 0;
 
-  &:hover:not(.active) {
+  &:hover {
     outline: var(--color-border-primary) 2px solid;
     outline-width: 2px;
     --icon-grade: 200;
@@ -127,11 +127,18 @@ site-navigation {
 
 
 /* Active nav item styles */
-.active {
+.active,
+site-navigation[active-item="item1"] .item1,
+site-navigation[active-item="item2"] .item2,
+site-navigation[active-item="item3"] .item3,
+site-navigation[active-item="item4"] .item4,
+site-navigation[active-item="item5"] .item5 {
   transition: none;
   font-variation-settings: 'GRAD' 100;
   color: var(--color-text-base);
   background: transparent;
+  outline-width: 0;
+  outline-color: transparent;
 
   .icon {
     font-variation-settings: "FILL" 1, "GRAD" var(--icon-grade-emphasis);
@@ -211,19 +218,12 @@ site-navigation {
     z-index: 1;
 }
 
-/* Set nav-background-position variable with :has() selectors */
-nav:has(.nav-item:nth-child(1).active) { --nav-background-position: 1; }
-nav:has(.nav-item:nth-child(2).active) { --nav-background-position: 2; }
-nav:has(.nav-item:nth-child(3).active) { --nav-background-position: 3; }
-nav:has(.nav-item:nth-child(4).active) { --nav-background-position: 4; }
-nav:has(.nav-item:nth-child(5).active) { --nav-background-position: 5; }
-
-/* Fallback for li > a.nav-item.active structure */
-nav:has(li:nth-child(1) > a.nav-item.active) { --nav-background-position: 1; }
-nav:has(li:nth-child(2) > a.nav-item.active) { --nav-background-position: 2; }
-nav:has(li:nth-child(3) > a.nav-item.active) { --nav-background-position: 3; }
-nav:has(li:nth-child(4) > a.nav-item.active) { --nav-background-position: 4; }
-nav:has(li:nth-child(5) > a.nav-item.active) { --nav-background-position: 5; }
+/* Set nav-background-position variable based on active-item attribute */
+site-navigation[active-item="item1"] nav { --nav-background-position: 1; }
+site-navigation[active-item="item2"] nav { --nav-background-position: 2; }
+site-navigation[active-item="item3"] nav { --nav-background-position: 3; }
+site-navigation[active-item="item4"] nav { --nav-background-position: 4; }
+site-navigation[active-item="item5"] nav { --nav-background-position: 5; }
 
 @media (max-width: 768px) {
   .nav-background {
@@ -452,11 +452,15 @@ theme-slider {
       white-space: nowrap;
     }
 
-    &:hover:not(.active) {
+    &:hover {
       background-color: transparent;
     }
 
-    &.active {
+    site-navigation[active-item="item1"] &.item1,
+    site-navigation[active-item="item2"] &.item2,
+    site-navigation[active-item="item3"] &.item3,
+    site-navigation[active-item="item4"] &.item4,
+    site-navigation[active-item="item5"] &.item5 {
       background-color: transparent;
       color: #006e9b;
     }
@@ -473,12 +477,12 @@ theme-slider {
     width: var(--nav-bg-width, calc(20% - 8px));
   }
   
-  /* :has() selector fallbacks for browsers that support it */
-  nav:has(.item1.active) .nav-background { --nav-bg-left: calc(0 * 20% + 4px); --nav-bg-width: calc(20% - 8px); }
-  nav:has(.item2.active) .nav-background { --nav-bg-left: calc(1 * 20% + 4px); --nav-bg-width: calc(20% - 8px); }
-  nav:has(.item3.active) .nav-background { --nav-bg-left: calc(2 * 20% + 4px); --nav-bg-width: calc(20% - 8px); }
-  nav:has(.item4.active) .nav-background { --nav-bg-left: calc(3 * 20% + 4px); --nav-bg-width: calc(20% - 8px); }
-  nav:has(.item5.active) .nav-background { --nav-bg-left: calc(4 * 20% + 4px); --nav-bg-width: calc(20% - 8px); }
+  /* Active state position for mobile */
+  site-navigation[active-item="item1"] .nav-background { --nav-bg-left: calc(0 * 20% + 4px); --nav-bg-width: calc(20% - 8px); }
+  site-navigation[active-item="item2"] .nav-background { --nav-bg-left: calc(1 * 20% + 4px); --nav-bg-width: calc(20% - 8px); }
+  site-navigation[active-item="item3"] .nav-background { --nav-bg-left: calc(2 * 20% + 4px); --nav-bg-width: calc(20% - 8px); }
+  site-navigation[active-item="item4"] .nav-background { --nav-bg-left: calc(3 * 20% + 4px); --nav-bg-width: calc(20% - 8px); }
+  site-navigation[active-item="item5"] .nav-background { --nav-bg-left: calc(4 * 20% + 4px); --nav-bg-width: calc(20% - 8px); }
 }
 
 /* Mobile settings styles - apply globally but only visible on mobile */

--- a/src/components/navigation/navigation.js
+++ b/src/components/navigation/navigation.js
@@ -2,35 +2,12 @@ class SiteNavigation extends HTMLElement {
   constructor() {
     super();
     this.rendered = false;
-    this.lastPath = null;
-    this.lastActiveClass = null;
   }
 
   connectedCallback() {
     if (!this.rendered) {
       this.render();
       this.rendered = true;
-    } else {
-      // Only update active state if path changed
-      this.updateActiveState();
-    }
-  }
-
-  updateActiveState() {
-    const currentActiveClass = this.getAttribute('active-item') || this.getActiveItemClass();
-    
-    // Only update if active class changed
-    if (currentActiveClass !== this.lastActiveClass) {
-      const navItems = this.querySelectorAll('.nav-item');
-      navItems.forEach((item, index) => {
-        const itemClass = `item${index + 1}`;
-        if (currentActiveClass === itemClass) {
-          item.classList.add('active');
-        } else {
-          item.classList.remove('active');
-        }
-      });
-      this.lastActiveClass = currentActiveClass;
     }
   }
 
@@ -39,25 +16,20 @@ class SiteNavigation extends HTMLElement {
     const path = window.location.pathname;
     const depth = (path.match(/\//g) || []).length - 1;
     const baseUrl = depth === 0 ? '' : '../'.repeat(depth);
-    
-    // Get active item from attribute or fall back to URL detection
-    const activeClass = this.getAttribute('active-item') || this.getActiveItemClass();
-    this.lastActiveClass = activeClass;
-    this.lastPath = path;
-    
+
     // Create navigation template (cached for performance)
     if (!SiteNavigation.template) {
       SiteNavigation.template = this.createTemplate();
     }
-    
+
     // Clone template and update dynamic parts
     const clone = SiteNavigation.template.cloneNode(true);
-    
+
     // Update base URLs for all navigation links
     const links = clone.querySelectorAll('a[href]');
     links.forEach(link => {
       const href = link.getAttribute('href');
-      
+
       // Apply baseUrl to all relative links
       if (!href.startsWith('http') && !href.startsWith('#')) {
         const newHref = baseUrl + href;
@@ -68,20 +40,11 @@ class SiteNavigation extends HTMLElement {
         }
       }
     });
-    
-    // Update active state
-    const navItems = clone.querySelectorAll('.nav-item');
-    navItems.forEach((item, index) => {
-      const itemClass = `item${index + 1}`;
-      if (activeClass === itemClass) {
-        item.classList.add('active');
-      }
-    });
-    
+
     // Replace content
     this.innerHTML = '';
     this.appendChild(clone);
-    
+
     this.setupMobileSettings();
   }
 
@@ -171,25 +134,6 @@ class SiteNavigation extends HTMLElement {
       // Store event handlers for cleanup
       SiteNavigation.mobileEventHandlers = { toggleOpen, closeSettings, handleEscape };
     }
-  }
-
-  getActiveItemClass() {
-    const path = window.location.pathname;
-    
-    // Handle different path structures
-    if (path === '/' || path.endsWith('/index.html') || path.endsWith('/ben.cards/')) {
-      return 'item1';
-    } else if (path.includes('/fundamentals')) {
-      return 'item2';
-    } else if (path.includes('/designs')) {
-      return 'item3';
-    } else if (path.includes('/experiments')) {
-      return 'item4';
-    } else if (path.includes('/resources')) {
-      return 'item5';
-    }
-
-    return null;
   }
 
   disconnectedCallback() {


### PR DESCRIPTION
## Summary
- Strip dynamic `.active` class logic from `site-navigation` component to avoid late view-transition assignments
- Style navigation items purely through `active-item` attribute selectors in CSS, keeping active link handling declarative
- Update navigation background positioning rules for both desktop and mobile based on `active-item`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6890fbbd11b883239721712ac4bcef43