### PR TITLE
refactor: standardize head markup

### DIFF
--- a/designs/arvest/index.html
+++ b/designs/arvest/index.html
@@ -10,39 +10,30 @@
     gtag('js', new Date());
     gtag('config', 'G-PLX2X0J846');
   </script>
-  
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="preload" href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap" as="style" onload="this.rel='stylesheet'" />
+  <link rel="preload" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block" as="style" onload="this.rel='stylesheet'" />
+  <noscript>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block" rel="stylesheet" />
+  </noscript>
+
   <title>Ben Jennings</title>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1, viewport-fit=cover" />
 
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link rel="preload"
-    href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap"
-    as="style" onload="this.rel='stylesheet'" />
-  <link rel="preload"
-    href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block"
-    as="style" onload="this.rel='stylesheet'" />
-  <noscript>
-    <link
-      href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap"
-      rel="stylesheet" />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block"
-      rel="stylesheet" />
-  </noscript>
-
   <!-- Critical CSS - load first for view-transition-name definitions -->
   <link href="../../src/assets/styles/base/vars.css" rel="stylesheet" />
   <link href="../../src/assets/styles/base/index.css" rel="stylesheet" />
-  
+
   <!-- Critical JavaScript - theme initialization -->
   <script src="../../src/scripts/index.js"></script>
-  
+
   <!-- Web Components - preload then load -->
   <link rel="modulepreload" href="../../src/components/index.js" />
   <script type="module" src="../../src/components/index.js"></script>
-  
+
   <!-- View transition script - after CSS and components -->
   <script src="../../src/scripts/view-transition.js"></script>
 
@@ -50,12 +41,30 @@
   <link rel="expect" blocking="render" href="#project-header" />
   <link rel="expect" blocking="render" href="#project-image" />
   <link rel="expect" blocking="render" href="#project-title" />
-  
+
+  <!-- Prefetch Links -->
+  <link rel="expect" href="../../index.html" blocking="render" />
+  <link rel="expect" href="../../designs/" blocking="render" />
+  <link rel="expect" href="../../fundamentals/" blocking="render" />
+  <link rel="expect" href="../../experiments/" blocking="render" />
+  <link rel="expect" href="../../resources/" blocking="render" />
+  <script type="speculationrules">
+    {
+      "prerender": [
+        {
+          "urls": ["../../index.html", "../../designs/","../../fundamentals/","../../experiments/","../../resources/"],
+          "eagerness": "eager",
+          "referrer_policy": "same-origin"
+        }
+      ]
+    }
+  </script>
+
   <!-- Icons and Manifest -->
-  <link rel="apple-touch-icon" sizes="180x180" href="../../public/favicons/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="../../public/favicons/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="../../public/favicons/favicon-16x16.png">
-  <link rel="manifest" href="../../public/site.webmanifest">
+  <link rel="apple-touch-icon" sizes="180x180" href="../../public/favicons/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" sizes="32x32" href="../../public/favicons/favicon-32x32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="../../public/favicons/favicon-16x16.png" />
+  <link rel="manifest" href="../../public/site.webmanifest" />
 </head>
 
 <body id="page-container" class="page-container detail-page">

--- a/designs/dwellane/index.html
+++ b/designs/dwellane/index.html
@@ -1,10 +1,14 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <title>Ben Jennings</title>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width,initial-scale=1, viewport-fit=cover" />
-
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-PLX2X0J846"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+    gtag('config', 'G-PLX2X0J846');
+  </script>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link rel="preload" href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap" as="style" onload="this.rel='stylesheet'" />
@@ -14,12 +18,48 @@
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block" rel="stylesheet" />
   </noscript>
 
-  <script src="../../src/scripts/index.js"></script>
-  <link rel="modulepreload" href="../../src/components/index.js" />
-  <script type="module" src="../../src/components/index.js"></script>
-  <script src="../../src/scripts/view-transition.js"></script>
+  <title>Ben Jennings</title>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1, viewport-fit=cover" />
+
+  <!-- Critical CSS - load first for view-transition-name definitions -->
   <link href="../../src/assets/styles/base/vars.css" rel="stylesheet" />
   <link href="../../src/assets/styles/base/index.css" rel="stylesheet" />
+
+  <!-- Critical JavaScript - theme initialization -->
+  <script src="../../src/scripts/index.js"></script>
+
+  <!-- Web Components - preload then load -->
+  <link rel="modulepreload" href="../../src/components/index.js" />
+  <script type="module" src="../../src/components/index.js"></script>
+
+  <!-- View transition script - after CSS and components -->
+  <script src="../../src/scripts/view-transition.js"></script>
+
+  
+  <!-- Prefetch Links -->
+  <link rel="expect" href="../../index.html" blocking="render" />
+  <link rel="expect" href="../../designs/" blocking="render" />
+  <link rel="expect" href="../../fundamentals/" blocking="render" />
+  <link rel="expect" href="../../experiments/" blocking="render" />
+  <link rel="expect" href="../../resources/" blocking="render" />
+  <script type="speculationrules">
+    {
+      "prerender": [
+        {
+          "urls": ["../../index.html", "../../designs/","../../fundamentals/","../../experiments/","../../resources/"],
+          "eagerness": "eager",
+          "referrer_policy": "same-origin"
+        }
+      ]
+    }
+  </script>
+
+  <!-- Icons and Manifest -->
+  <link rel="apple-touch-icon" sizes="180x180" href="../../public/favicons/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" sizes="32x32" href="../../public/favicons/favicon-32x32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="../../public/favicons/favicon-16x16.png" />
+  <link rel="manifest" href="../../public/site.webmanifest" />
 </head>
 <body id="page-container" class="page-container detail-page">
   <site-navigation active-item="item3"></site-navigation>

--- a/designs/herff-jones/index.html
+++ b/designs/herff-jones/index.html
@@ -1,10 +1,14 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <title>Ben Jennings</title>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width,initial-scale=1, viewport-fit=cover" />
-
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-PLX2X0J846"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+    gtag('config', 'G-PLX2X0J846');
+  </script>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link rel="preload" href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap" as="style" onload="this.rel='stylesheet'" />
@@ -14,12 +18,48 @@
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block" rel="stylesheet" />
   </noscript>
 
-  <script src="../../src/scripts/index.js"></script>
-  <link rel="modulepreload" href="../../src/components/index.js" />
-  <script type="module" src="../../src/components/index.js"></script>
-  <script src="../../src/scripts/view-transition.js"></script>
+  <title>Ben Jennings</title>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1, viewport-fit=cover" />
+
+  <!-- Critical CSS - load first for view-transition-name definitions -->
   <link href="../../src/assets/styles/base/vars.css" rel="stylesheet" />
   <link href="../../src/assets/styles/base/index.css" rel="stylesheet" />
+
+  <!-- Critical JavaScript - theme initialization -->
+  <script src="../../src/scripts/index.js"></script>
+
+  <!-- Web Components - preload then load -->
+  <link rel="modulepreload" href="../../src/components/index.js" />
+  <script type="module" src="../../src/components/index.js"></script>
+
+  <!-- View transition script - after CSS and components -->
+  <script src="../../src/scripts/view-transition.js"></script>
+
+  
+  <!-- Prefetch Links -->
+  <link rel="expect" href="../../index.html" blocking="render" />
+  <link rel="expect" href="../../designs/" blocking="render" />
+  <link rel="expect" href="../../fundamentals/" blocking="render" />
+  <link rel="expect" href="../../experiments/" blocking="render" />
+  <link rel="expect" href="../../resources/" blocking="render" />
+  <script type="speculationrules">
+    {
+      "prerender": [
+        {
+          "urls": ["../../index.html", "../../designs/","../../fundamentals/","../../experiments/","../../resources/"],
+          "eagerness": "eager",
+          "referrer_policy": "same-origin"
+        }
+      ]
+    }
+  </script>
+
+  <!-- Icons and Manifest -->
+  <link rel="apple-touch-icon" sizes="180x180" href="../../public/favicons/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" sizes="32x32" href="../../public/favicons/favicon-32x32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="../../public/favicons/favicon-16x16.png" />
+  <link rel="manifest" href="../../public/site.webmanifest" />
 </head>
 <body id="page-container" class="page-container detail-page">
   <site-navigation active-item="item3"></site-navigation>

--- a/designs/index.html
+++ b/designs/index.html
@@ -6,41 +6,36 @@
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-PLX2X0J846"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
-    function gtag() {
-      dataLayer.push(arguments);
-    }
-    gtag("js", new Date());
-
-    gtag("config", "G-PLX2X0J846");
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+    gtag('config', 'G-PLX2X0J846');
   </script>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link rel="preload"
-    href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap"
-    as="style" onload="this.rel='stylesheet'" />
-  <link rel="preload"
-    href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block"
-    as="style" onload="this.rel='stylesheet'" />
+  <link rel="preload" href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap" as="style" onload="this.rel='stylesheet'" />
+  <link rel="preload" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block" as="style" onload="this.rel='stylesheet'" />
   <noscript>
-    <link
-      href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap"
-      rel="stylesheet" />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block"
-      rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block" rel="stylesheet" />
   </noscript>
 
   <title>Ben Jennings</title>
   <meta charset="UTF-8" />
   <meta name="description" content="A collection of projects by Ben Jennings" />
   <meta name="viewport" content="width=device-width,initial-scale=1, viewport-fit=cover" />
+
+  <!-- Critical CSS - load first for view-transition-name definitions -->
+  <link href="../src/assets/styles/base/vars.css" rel="stylesheet" />
+  <link href="../src/assets/styles/base/index.css" rel="stylesheet" />
+
+  <!-- Critical JavaScript - theme initialization -->
   <script src="../src/scripts/index.js"></script>
 
+  <!-- Web Components - preload then load -->
   <link rel="modulepreload" href="../src/components/index.js" />
   <script type="module" src="../src/components/index.js"></script>
 
-  <link href="../src/assets/styles/base/vars.css" rel="stylesheet" />
-  <link href="../src/assets/styles/base/index.css" rel="stylesheet" />
+  <!-- View transition script - after CSS and components -->
   <script src="../src/scripts/view-transition.js"></script>
 
   <!-- Render blocking for view transition card elements -->
@@ -64,22 +59,16 @@
   <link rel="expect" href="../resources/" blocking="render" />
 
   <script type="speculationrules">
-      {
-        "prerender": [
-          {
-            "urls": [
-              "../index.html",
-              "../designs/",
-              "../fundamentals/",
-              "../experiments/",
-              "../resources/"
-            ],
-            "eagerness": "eager",
-            "referrer_policy": "same-origin"
-          }
-        ]
-      }
-    </script>
+    {
+      "prerender": [
+        {
+          "urls": ["../index.html", "../designs/","../fundamentals/","../experiments/","../resources/"],
+          "eagerness": "eager",
+          "referrer_policy": "same-origin"
+        }
+      ]
+    }
+  </script>
 
   <!-- Icons and Manifest -->
   <link rel="apple-touch-icon" sizes="180x180" href="../public/favicons/apple-touch-icon.png" />

--- a/designs/pls/index.html
+++ b/designs/pls/index.html
@@ -2,33 +2,65 @@
 <html lang="en">
 
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-PLX2X0J846"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+    gtag('config', 'G-PLX2X0J846');
+  </script>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="preload" href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap" as="style" onload="this.rel='stylesheet'" />
+  <link rel="preload" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block" as="style" onload="this.rel='stylesheet'" />
+  <noscript>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block" rel="stylesheet" />
+  </noscript>
+
   <title>Ben Jennings</title>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1, viewport-fit=cover" />
 
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link rel="preload"
-    href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap"
-    as="style" onload="this.rel='stylesheet'" />
-  <link rel="preload"
-    href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block"
-    as="style" onload="this.rel='stylesheet'" />
-  <noscript>
-    <link
-      href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap"
-      rel="stylesheet" />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block"
-      rel="stylesheet" />
-  </noscript>
-
-  <script src="../../src/scripts/index.js"></script>
-  <link rel="modulepreload" href="../../src/components/index.js" />
-  <script type="module" src="../../src/components/index.js"></script>
-  <script src="../../src/scripts/view-transition.js"></script>
+  <!-- Critical CSS - load first for view-transition-name definitions -->
   <link href="../../src/assets/styles/base/vars.css" rel="stylesheet" />
   <link href="../../src/assets/styles/base/index.css" rel="stylesheet" />
+
+  <!-- Critical JavaScript - theme initialization -->
+  <script src="../../src/scripts/index.js"></script>
+
+  <!-- Web Components - preload then load -->
+  <link rel="modulepreload" href="../../src/components/index.js" />
+  <script type="module" src="../../src/components/index.js"></script>
+
+  <!-- View transition script - after CSS and components -->
+  <script src="../../src/scripts/view-transition.js"></script>
+
+  
+  <!-- Prefetch Links -->
+  <link rel="expect" href="../../index.html" blocking="render" />
+  <link rel="expect" href="../../designs/" blocking="render" />
+  <link rel="expect" href="../../fundamentals/" blocking="render" />
+  <link rel="expect" href="../../experiments/" blocking="render" />
+  <link rel="expect" href="../../resources/" blocking="render" />
+  <script type="speculationrules">
+    {
+      "prerender": [
+        {
+          "urls": ["../../index.html", "../../designs/","../../fundamentals/","../../experiments/","../../resources/"],
+          "eagerness": "eager",
+          "referrer_policy": "same-origin"
+        }
+      ]
+    }
+  </script>
+
+  <!-- Icons and Manifest -->
+  <link rel="apple-touch-icon" sizes="180x180" href="../../public/favicons/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" sizes="32x32" href="../../public/favicons/favicon-32x32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="../../public/favicons/favicon-16x16.png" />
+  <link rel="manifest" href="../../public/site.webmanifest" />
 </head>
 
 <body id="page-container" class="page-container detail-page">

--- a/fundamentals/index.html
+++ b/fundamentals/index.html
@@ -8,40 +8,34 @@
     window.dataLayer = window.dataLayer || [];
     function gtag() { dataLayer.push(arguments); }
     gtag('js', new Date());
-
     gtag('config', 'G-PLX2X0J846');
-
-
   </script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="preload"
-    href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap"
-    as="style" onload="this.rel='stylesheet'">
-  <link rel="preload"
-    href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block"
-    as="style" onload="this.rel='stylesheet'">
+  <link rel="preload" href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap" as="style" onload="this.rel='stylesheet'">
+  <link rel="preload" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block" as="style" onload="this.rel='stylesheet'">
   <noscript>
-    <link
-      href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap"
-      rel="stylesheet">
-    <link
-      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block"
-      rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block" rel="stylesheet">
   </noscript>
 
- 
   <title>Ben Jennings</title>
   <meta charset="UTF-8" />
   <meta name="description" content="A collection of projects by Ben Jennings" />
   <meta name="viewport" content="width=device-width,initial-scale=1, viewport-fit=cover" />
+
+  <!-- Critical CSS - load first for view-transition-name definitions -->
+  <link href="../src/assets/styles/base/vars.css" rel="stylesheet" />
+  <link href="../src/assets/styles/base/index.css" rel="stylesheet" />
+
+  <!-- Critical JavaScript - theme initialization -->
   <script src="../src/scripts/index.js"></script>
 
+  <!-- Web Components - preload then load -->
   <link rel="modulepreload" href="../src/components/index.js" />
   <script type="module" src="../src/components/index.js"></script>
 
-  <link href="../src/assets/styles/base/vars.css" rel="stylesheet" />
-  <link href="../src/assets/styles/base/index.css" rel="stylesheet" />
+  <!-- View transition script - after CSS and components -->
   <script src="../src/scripts/view-transition.js"></script>
 
   <!-- Prefetch Links -->
@@ -53,13 +47,13 @@
     {
       "prerender": [
         {
-          "urls": ["index.html", "designs/","fundamentals/","experiments/","resources/"],
+          "urls": ["../index.html", "../designs/","../fundamentals/","../experiments/","../resources/"],
           "eagerness": "eager",
           "referrer_policy": "same-origin"
         }
       ]
     }
-    </script>
+  </script>
 
   <!-- Icons and Manifest -->
   <link rel="apple-touch-icon" sizes="180x180" href="../public/favicons/apple-touch-icon.png">

--- a/fundamentals/simplicity/index.html
+++ b/fundamentals/simplicity/index.html
@@ -8,38 +8,35 @@
     window.dataLayer = window.dataLayer || [];
     function gtag() { dataLayer.push(arguments); }
     gtag('js', new Date());
-
     gtag('config', 'G-PLX2X0J846');
-
-
   </script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="preload"
-    href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap"
-    as="style" onload="this.rel='stylesheet'">
-  <link rel="preload"
-    href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block"
-    as="style" onload="this.rel='stylesheet'">
+  <link rel="preload" href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap" as="style" onload="this.rel='stylesheet'">
+  <link rel="preload" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block" as="style" onload="this.rel='stylesheet'">
   <noscript>
-    <link
-      href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap"
-      rel="stylesheet">
-    <link
-      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block"
-      rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block" rel="stylesheet">
   </noscript>
 
   <title>Ben Jennings</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1, viewport-fit=cover" />
-  <script src="../../src/scripts/index.js"></script>
 
-  <link rel="modulepreload" href="../../src/components/index.js" />
-  <script type="module" src="../../src/components/index.js"></script>
-  <script src="../../src/scripts/view-transition.js"></script>
+  <!-- Critical CSS - load first for view-transition-name definitions -->
   <link href="../../src/assets/styles/base/vars.css" rel="stylesheet" />
   <link href="../../src/assets/styles/base/index.css" rel="stylesheet" />
+
+  <!-- Critical JavaScript - theme initialization -->
+  <script src="../../src/scripts/index.js"></script>
+
+  <!-- Web Components - preload then load -->
+  <link rel="modulepreload" href="../../src/components/index.js" />
+  <script type="module" src="../../src/components/index.js"></script>
+
+  <!-- View transition script - after CSS and components -->
+  <script src="../../src/scripts/view-transition.js"></script>
+
   <!-- Prefetch Links -->
   <link rel="expect" href="../../index.html" blocking="render" />
   <link rel="expect" href="../../designs/" blocking="render" />
@@ -49,13 +46,13 @@
     {
       "prerender": [
         {
-          "urls": ["index.html", "designs/","fundamentals/","experiments/","resources/"],
+          "urls": ["../../index.html", "../../designs/","../../fundamentals/","../../experiments/","../../resources/"],
           "eagerness": "eager",
           "referrer_policy": "same-origin"
         }
       ]
     }
-    </script>
+  </script>
 
   <!-- Icons and Manifest -->
   <link rel="apple-touch-icon" sizes="180x180" href="../../public/favicons/apple-touch-icon.png">

--- a/index.html
+++ b/index.html
@@ -8,42 +8,34 @@
     window.dataLayer = window.dataLayer || [];
     function gtag() { dataLayer.push(arguments); }
     gtag('js', new Date());
-
     gtag('config', 'G-PLX2X0J846');
-
-
   </script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="preload"
-    href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap"
-    as="style" onload="this.rel='stylesheet'">
-  <link rel="preload"
-    href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block"
-    as="style" onload="this.rel='stylesheet'">
+  <link rel="preload" href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap" as="style" onload="this.rel='stylesheet'">
+  <link rel="preload" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block" as="style" onload="this.rel='stylesheet'">
   <noscript>
-    <link
-      href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap"
-      rel="stylesheet">
-    <link
-      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block"
-      rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block" rel="stylesheet">
   </noscript>
 
   <title>Ben Jennings</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1, viewport-fit=cover" />
-  
 
-  
+  <!-- Critical CSS - load first for view-transition-name definitions -->
+  <link href="src/assets/styles/base/vars.css" rel="stylesheet" />
+  <link href="src/assets/styles/base/index.css" rel="stylesheet" />
 
-  
-  <link rel="modulepreload" href="../src/components/index.js" />
-  <script type="module" src="../src/components/index.js"></script>
-  
-  <link href="../src/assets/styles/base/vars.css" rel="stylesheet" />
-  <link href="../src/assets/styles/base/index.css" rel="stylesheet" />
-  <script src="../src/scripts/view-transition.js"></script>
+  <!-- Critical JavaScript - theme initialization -->
+  <script src="src/scripts/index.js"></script>
+
+  <!-- Web Components - preload then load -->
+  <link rel="modulepreload" href="src/components/index.js" />
+  <script type="module" src="src/components/index.js"></script>
+
+  <!-- View transition script - after CSS and components -->
+  <script src="src/scripts/view-transition.js"></script>
 
   <!-- Prefetch Links -->
   <link rel="expect" href="designs/" blocking="render" />
@@ -60,16 +52,13 @@
         }
       ]
     }
-    </script>
-
+  </script>
 
   <!-- Icons and Manifest -->
   <link rel="apple-touch-icon" sizes="180x180" href="public/favicons/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="public/favicons/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="public/favicons/favicon-16x16.png">
   <link rel="manifest" href="public/site.webmanifest">
-
-
 </head>
 
 <body id="page-container" class="page-container">

--- a/resources/index.html
+++ b/resources/index.html
@@ -17,19 +17,11 @@
   </script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="preload"
-    href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap"
-    as="style" onload="this.rel='stylesheet'">
-  <link rel="preload"
-    href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&icon_names=account_balance,account_tree,close,cloud,construction,dark_mode,demography,deployed_code,design_services,developer_board,experiment,folder_open,integration_instructions,light_mode,link,psychology,psychology_alt,routine,tune,view_in_ar,waving_hand,web&display=block"
-    as="style" onload="this.rel='stylesheet'">
+  <link rel="preload" href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap" as="style" onload="this.rel='stylesheet'">
+  <link rel="preload" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block" as="style" onload="this.rel='stylesheet'">
   <noscript>
-    <link
-      href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap"
-      rel="stylesheet">
-    <link
-      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&icon_names=account_balance,account_tree,close,cloud,construction,dark_mode,demography,deployed_code,design_services,developer_board,experiment,folder_open,integration_instructions,light_mode,link,psychology,psychology_alt,routine,tune,view_in_ar,waving_hand,web&display=block"
-      rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block" rel="stylesheet">
   </noscript>
   
   <title>Ben Jennings</title>

--- a/test.html
+++ b/test.html
@@ -8,51 +8,41 @@
     window.dataLayer = window.dataLayer || [];
     function gtag() { dataLayer.push(arguments); }
     gtag('js', new Date());
-
     gtag('config', 'G-PLX2X0J846');
-
-
-
-
   </script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="preload"
-    href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap"
-    as="style" onload="this.rel='stylesheet'">
-  <link rel="preload"
-    href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&icon_names=account_balance,account_tree,close,cloud,construction,dark_mode,demography,deployed_code,design_services,developer_board,experiment,folder_open,integration_instructions,light_mode,link,psychology,psychology_alt,routine,tune,view_in_ar,waving_hand,web&display=block"
-    as="style" onload="this.rel='stylesheet'">
+  <link rel="preload" href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap" as="style" onload="this.rel='stylesheet'">
+  <link rel="preload" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block" as="style" onload="this.rel='stylesheet'">
   <noscript>
-    <link
-      href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap"
-      rel="stylesheet">
-    <link
-      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&icon_names=account_balance,account_tree,close,cloud,construction,dark_mode,demography,deployed_code,design_services,developer_board,experiment,folder_open,integration_instructions,light_mode,link,psychology,psychology_alt,routine,tune,view_in_ar,waving_hand,web&display=block"
-      rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wdth,wght,GRAD@8..144,25..151,100..1000,-200..150&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block" rel="stylesheet">
   </noscript>
 
-  <link href="src/assets/styles/base/vars.css" rel="stylesheet" />
-  <link href="src/assets/styles/index.css" rel="stylesheet" />
   <title>Ben Jennings</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1, viewport-fit=cover" />
-  <script src="/js/index.js"></script>
 
+  <!-- Critical CSS - load first for view-transition-name definitions -->
+  <link href="src/assets/styles/base/vars.css" rel="stylesheet" />
+  <link href="src/assets/styles/base/index.css" rel="stylesheet" />
 
-  <!-- Preconnect -->
+  <!-- Critical JavaScript - theme initialization -->
+  <script src="src/scripts/index.js"></script>
 
+  <!-- Web Components - preload then load -->
+  <link rel="modulepreload" href="src/components/index.js" />
+  <script type="module" src="src/components/index.js"></script>
 
-  <link rel="modulepreload" href="/js/components/index.js" />
-  <script type="module" src="/js/components/index.js"></script>
-  <script src="/js/view-transition.js"></script>
-
+  <!-- View transition script - after CSS and components -->
+  <script src="src/scripts/view-transition.js"></script>
 
   <!-- Prefetch Links -->
-  <link rel="expect" href="/index.html" blocking="render" />
-  <link rel="expect" href="/fundamentals/" blocking="render" />
-  <link rel="expect" href="/experiments/" blocking="render" />
-  <link rel="expect" href="/designs/" blocking="render" />
+  <link rel="expect" href="index.html" blocking="render" />
+  <link rel="expect" href="fundamentals/" blocking="render" />
+  <link rel="expect" href="experiments/" blocking="render" />
+  <link rel="expect" href="designs/" blocking="render" />
+  <link rel="expect" href="resources/" blocking="render" />
   <script type="speculationrules">
     {
       "prerender": [
@@ -63,15 +53,14 @@
         }
       ]
     }
-    </script>
+  </script>
 
   <!-- Icons and Manifest -->
-  <link rel="apple-touch-icon" sizes="180x180" href="/public/favicons/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/public/favicons/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/public/favicons/favicon-16x16.png">
-  <link rel="manifest" href="/site.webmanifest">
-    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
-
+  <link rel="apple-touch-icon" sizes="180x180" href="public/favicons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="public/favicons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="public/favicons/favicon-16x16.png">
+  <link rel="manifest" href="public/site.webmanifest">
+  <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
 </head>
 
 <body>


### PR DESCRIPTION
## Summary
- ensure all HTML pages share consistent `<head>` structure
- load critical CSS and JS in optimal order

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689101f560e08323802aa67d000037c3